### PR TITLE
chore: add scratch directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Scratch work directories
+.scratch*


### PR DESCRIPTION
Any .scratch* directories will not be commit to git.