### PR TITLE
Feat: initialize db with sqitch

### DIFF
--- a/schema/deploy/create-roles.sql
+++ b/schema/deploy/create-roles.sql
@@ -1,0 +1,48 @@
+-- Deploy eed:create-roles to pg
+
+begin;
+
+-- The create roles affects the database globally. Cannot drop the roles once created.
+do
+$do$
+begin
+
+  if not exists (
+    select true
+    from   pg_catalog.pg_roles
+    where  rolname = 'eed_internal') then
+
+    create role eed_internal;
+  end if;
+
+  if not exists (
+    select true
+    from   pg_catalog.pg_roles
+    where  rolname = 'eed_external') then
+
+    create role eed_external;
+  end if;
+
+  if not exists (
+    select true
+    from   pg_catalog.pg_roles
+    where  rolname = 'eed_admin') then
+
+    create role eed_admin;
+  end if;
+
+  if not exists (
+    select true
+    from   pg_catalog.pg_roles
+    where  rolname = 'eedapp') then
+
+    create user eedapp;
+  end if;
+
+  grant eed_admin, eed_internal, eed_external to eedapp;
+  execute format('grant create, connect on database %I to eedapp', current_database());
+
+end
+$do$;
+
+commit;

--- a/schema/deploy/schemas/main.sql
+++ b/schema/deploy/schemas/main.sql
@@ -1,0 +1,9 @@
+-- Deploy eed:schema/eed to pg
+
+begin;
+
+create schema eed;
+grant usage on schema eed to eed_internal, eed_external, eed_admin;
+comment on schema eed is 'The main schema for the eed application.';
+
+commit;

--- a/schema/deploy/schemas/private.sql
+++ b/schema/deploy/schemas/private.sql
@@ -1,0 +1,9 @@
+-- Deploy eed:schema/eed_private to pg
+
+begin;
+
+create schema eed_private;
+grant usage on schema eed_private to eed_internal, eed_external, eed_admin;
+comment on schema eed_private is 'The private schema for the eed application. It contains utility functions which should not be available directly through the API.';
+
+commit;

--- a/schema/deploy/tables/data_provider.sql
+++ b/schema/deploy/tables/data_provider.sql
@@ -1,0 +1,7 @@
+-- Deploy eed:tables/data_provider to pg
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/schema/deploy/trigger_functions/update_timestamps.sql
+++ b/schema/deploy/trigger_functions/update_timestamps.sql
@@ -1,0 +1,59 @@
+-- Deploy eed:trigger_functions/update_timestamps to pg
+-- requires: schemas/private
+
+begin;
+
+create or replace function eed_private.update_timestamps()
+  returns trigger as $$
+
+declare
+  user_sub uuid;
+  user_id int;
+
+begin
+  user_sub := (select sub from eed.session());
+  user_id := (select id from eed.eed_user where eed_user.uuid = user_sub);
+  if tg_op = 'INSERT' then
+    if to_jsonb(new) ? 'created_at' then
+      new.created_at = now();
+      new.created_by = user_id;
+    end if;
+    if to_jsonb(new) ? 'updated_at' then
+      new.updated_at = now();
+      new.updated_by = user_id;
+    end if;
+  elsif tg_op = 'UPDATE' then
+    if to_jsonb(new) ? 'archived_at' then
+      if old.archived_at is distinct from new.archived_at and new.archived_at is not null then
+        new.archived_at = now();
+        new.archived_by = user_id;
+      end if;
+    end if;
+    if to_jsonb(new) ? 'updated_at' then
+      new.updated_at = greatest(now(), old.updated_at + interval '1 millisecond');
+      new.updated_by = user_id;
+    end if;
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+grant execute on function eed_private.update_timestamps to eed_internal, eed_external, eed_admin;
+
+comment on function eed_private.update_timestamps()
+  is $$
+  a trigger to set created_at and updated_at columns.
+  example usage:
+
+  create table some_schema.some_table (
+    ...
+    created_at timestamp with time zone not null default now(),
+    updated_at timestamp with time zone not null default now()
+  );
+  create trigger _100_timestamps
+    before insert or update on some_schema.some_table
+    for each row
+    execute procedure eed_private.update_timestamps();
+  $$;
+
+commit;

--- a/schema/deploy/util_functions/grant_permissions.sql
+++ b/schema/deploy/util_functions/grant_permissions.sql
@@ -1,0 +1,67 @@
+-- Deploy eed:util_functions/grant_permissions to pg
+
+begin;
+
+-- Grants permission for all columns in a table
+create or replace function eed_private.grant_permissions(
+  operation text,
+  table_name text,
+  role_name text,
+  table_schema text default 'eed'
+)
+returns void
+as
+$function$
+  declare
+    column_name text;
+  begin
+    if (lower(operation) not in ('select', 'insert', 'update', 'delete')) then
+      raise exception 'invalid operation variable. Must be one of [select, insert, update, delete]';
+    else
+      execute format(
+        'grant ' || quote_ident(operation) ||
+        ' on ' || quote_ident(table_schema) || '.' || quote_ident(table_name) ||
+        ' to ' || quote_ident(role_name)
+      );
+    end if;
+  end;
+$function$
+language 'plpgsql' volatile;
+
+comment on function eed_private.grant_permissions(text, text, text, text) is
+  'A generic function for granting access-control permissions on all columns of a table';
+
+-- Grants permissions on speeedic columns in a table
+create or replace function eed_private.grant_permissions(
+  operation text,
+  table_name text,
+  role_name text,
+  column_names text[],
+  table_schema text default 'eed'
+)
+returns void
+as
+$function$
+  declare
+    column_name text;
+  begin
+    if (lower(operation) not in ('select', 'insert', 'update', 'delete')) then
+      raise exception 'invalid operation variable. Must be one of [select, insert, update, delete]';
+    else
+      foreach column_name in ARRAY column_names
+      loop
+        execute format(
+          'grant ' || quote_ident(operation) || ' (' || quote_ident(column_name) ||
+          ') on ' || quote_ident(table_schema) || '.' || quote_ident(table_name) ||
+          ' to ' || quote_ident(role_name)
+        );
+      end loop;
+    end if;
+  end;
+$function$
+language 'plpgsql' volatile;
+
+comment on function eed_private.grant_permissions(text, text, text, text[], text) is
+  'A generic function for granting access-control permissions on speeedic columns of a table';
+
+commit;

--- a/schema/deploy/util_functions/grant_permissions.sql
+++ b/schema/deploy/util_functions/grant_permissions.sql
@@ -31,7 +31,7 @@ language 'plpgsql' volatile;
 comment on function eed_private.grant_permissions(text, text, text, text) is
   'A generic function for granting access-control permissions on all columns of a table';
 
--- Grants permissions on speeedic columns in a table
+-- Grants permissions on select columns in a table
 create or replace function eed_private.grant_permissions(
   operation text,
   table_name text,

--- a/schema/deploy/util_functions/grant_permissions.sql
+++ b/schema/deploy/util_functions/grant_permissions.sql
@@ -62,6 +62,6 @@ $function$
 language 'plpgsql' volatile;
 
 comment on function eed_private.grant_permissions(text, text, text, text[], text) is
-  'A generic function for granting access-control permissions on speeedic columns of a table';
+  'A generic function for granting access-control permissions on specific columns of a table';
 
 commit;

--- a/schema/deploy/util_functions/verify_function_not_present.sql
+++ b/schema/deploy/util_functions/verify_function_not_present.sql
@@ -1,0 +1,20 @@
+-- Deploy eed:util_functions/verify_function_not_present to pg
+
+begin;
+
+create or replace function eed_private.verify_function_not_present(function_name text)
+returns boolean
+as
+$function$
+begin
+  if (select exists(select * from pg_proc where proname=function_name)) then
+    raise exception '% exists when it should not', function_name;
+  else
+    return true;
+  end if;
+end;
+$function$
+language 'plpgsql' stable;
+comment on function eed_private.verify_function_not_present(text) is 'Utility function to use in a change verification or test to ensure that a function was deleted';
+
+commit;

--- a/schema/revert/create-roles.sql
+++ b/schema/revert/create-roles.sql
@@ -1,0 +1,14 @@
+-- Revert eed:create-roles from pg
+
+begin;
+
+do
+$do$
+begin
+raise NOTICE 'Created roles may be used in other projects, and need to be manually deleted if needed';
+end;
+$do$;
+
+select true;
+
+commit;

--- a/schema/revert/schemas/main.sql
+++ b/schema/revert/schemas/main.sql
@@ -1,0 +1,7 @@
+-- Revert eed:schema/eed from pg
+
+begin;
+
+drop schema eed;
+
+commit;

--- a/schema/revert/schemas/private.sql
+++ b/schema/revert/schemas/private.sql
@@ -1,0 +1,7 @@
+-- Revert eed:schema/eed_private from pg
+
+begin;
+
+drop schema eed_private;
+
+commit;

--- a/schema/revert/tables/data_provider.sql
+++ b/schema/revert/tables/data_provider.sql
@@ -1,0 +1,7 @@
+-- Revert eed:tables/data_provider from pg
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/schema/revert/trigger_functions/update_timestamps.sql
+++ b/schema/revert/trigger_functions/update_timestamps.sql
@@ -1,0 +1,7 @@
+-- Revert eed:trigger_functions/update_timestamps from pg
+
+begin;
+
+drop function eed_private.update_timestamps();
+
+commit;

--- a/schema/revert/util_functions/grant_permissions.sql
+++ b/schema/revert/util_functions/grant_permissions.sql
@@ -1,0 +1,8 @@
+-- Revert eed:util_functions/grant_permissions from pg
+
+begin;
+
+drop function eed_private.grant_permissions(text, text, text, text);
+drop function eed_private.grant_permissions(text, text, text, text[], text);
+
+commit;

--- a/schema/revert/util_functions/verify_function_not_present.sql
+++ b/schema/revert/util_functions/verify_function_not_present.sql
@@ -1,0 +1,7 @@
+-- Revert eed:util_functions/verify_function_not_present from pg
+
+begin;
+
+drop function eed_private.verify_function_not_present(text);
+
+commit;

--- a/schema/sqitch.conf
+++ b/schema/sqitch.conf
@@ -1,0 +1,8 @@
+[core]
+	engine = pg
+	# plan_file = sqitch.plan
+	# top_dir = .
+# [engine "pg"]
+	# target = db:pg:
+	# registry = sqitch
+	# client = psql

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -2,3 +2,4 @@
 %project=eed
 %uri=https://github.com/button-inc/emissions-elt-demo
 
+create-roles 2022-08-28T23:59:50Z Mike Vesprini <mike@button.is> # Create the roles used by the application

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -7,3 +7,4 @@ schemas/main 2022-08-29T00:08:53Z Mike Vesprini <mike@button.is> # Create the ee
 schemas/private 2022-08-29T00:11:29Z Mike Vesprini <mike@button.is> # Create the eed_private schema
 util_functions/verify_function_not_present 2022-08-29T00:24:58Z Mike Vesprini <mike@button.is> # Create private util function to verify a function is not present
 util_functions/grant_permissions 2022-08-29T00:31:54Z Mike Vesprini <mike@button.is> # Private util-function to grant permissions
+trigger_functions/update_timestamps 2022-08-29T02:45:59Z Mike Vesprini <mike@button.is> # Create the eed_private.update_timestamps trigger function

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -1,0 +1,4 @@
+%syntax-version=1.0.0
+%project=eed
+%uri=https://github.com/button-inc/emissions-elt-demo
+

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -4,3 +4,4 @@
 
 create-roles 2022-08-28T23:59:50Z Mike Vesprini <mike@button.is> # Create the roles used by the application
 schemas/main 2022-08-29T00:08:53Z Mike Vesprini <mike@button.is> # Create the eed schema
+schemas/private 2022-08-29T00:11:29Z Mike Vesprini <mike@button.is> # Create the eed_private schema

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -5,3 +5,4 @@
 create-roles 2022-08-28T23:59:50Z Mike Vesprini <mike@button.is> # Create the roles used by the application
 schemas/main 2022-08-29T00:08:53Z Mike Vesprini <mike@button.is> # Create the eed schema
 schemas/private 2022-08-29T00:11:29Z Mike Vesprini <mike@button.is> # Create the eed_private schema
+util_functions/verify_function_not_present 2022-08-29T00:24:58Z Mike Vesprini <mike@button.is> # Create private util function to verify a function is not present

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -6,3 +6,4 @@ create-roles 2022-08-28T23:59:50Z Mike Vesprini <mike@button.is> # Create the ro
 schemas/main 2022-08-29T00:08:53Z Mike Vesprini <mike@button.is> # Create the eed schema
 schemas/private 2022-08-29T00:11:29Z Mike Vesprini <mike@button.is> # Create the eed_private schema
 util_functions/verify_function_not_present 2022-08-29T00:24:58Z Mike Vesprini <mike@button.is> # Create private util function to verify a function is not present
+util_functions/grant_permissions 2022-08-29T00:31:54Z Mike Vesprini <mike@button.is> # Private util-function to grant permissions

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -3,3 +3,4 @@
 %uri=https://github.com/button-inc/emissions-elt-demo
 
 create-roles 2022-08-28T23:59:50Z Mike Vesprini <mike@button.is> # Create the roles used by the application
+schemas/main 2022-08-29T00:08:53Z Mike Vesprini <mike@button.is> # Create the eed schema

--- a/schema/verify/create-roles.sql
+++ b/schema/verify/create-roles.sql
@@ -1,0 +1,24 @@
+-- Verify eed:create-roles on pg
+
+begin;
+
+do
+$verify$
+begin
+
+
+  if(select not exists(select true from pg_roles where rolname='eed_internal')) then
+    raise exception 'role eed_internal does not exist.';
+
+  elsif(select not exists(select true from pg_roles where rolname='eed_external')) then
+    raise exception 'role eed_external does not exist.';
+
+  elsif(select not exists(select true from pg_roles where rolname='eed_admin')) then
+    raise exception 'role eed_admin does not exist.';
+
+  end if;
+
+end
+$verify$;
+
+rollback;

--- a/schema/verify/schemas/main.sql
+++ b/schema/verify/schemas/main.sql
@@ -1,0 +1,7 @@
+-- Verify eed:schema/eed on pg
+
+begin;
+
+select pg_catalog.has_schema_privilege('eed', 'usage');
+
+rollback;

--- a/schema/verify/schemas/private.sql
+++ b/schema/verify/schemas/private.sql
@@ -1,0 +1,7 @@
+-- Verify eed:schema/eed_private on pg
+
+begin;
+
+select pg_catalog.has_schema_privilege('eed_private', 'usage');
+
+rollback;

--- a/schema/verify/tables/data_provider.sql
+++ b/schema/verify/tables/data_provider.sql
@@ -1,0 +1,7 @@
+-- Verify eed:tables/data_provider on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;

--- a/schema/verify/trigger_functions/update_timestamps.sql
+++ b/schema/verify/trigger_functions/update_timestamps.sql
@@ -1,0 +1,7 @@
+-- Verify eed:function_update_timestamps on pg
+
+begin;
+
+select pg_get_functiondef('eed_private.update_timestamps()'::regprocedure);
+
+rollback;

--- a/schema/verify/util_functions/grant_permissions.sql
+++ b/schema/verify/util_functions/grant_permissions.sql
@@ -1,0 +1,8 @@
+-- Verify eed:database_functions/grant_permissions on pg
+
+begin;
+
+select pg_get_functiondef('eed_private.grant_permissions(text,text,text,text)'::regprocedure);
+select pg_get_functiondef('eed_private.grant_permissions(text,text,text,text[],text)'::regprocedure);
+
+rollback;

--- a/schema/verify/util_functions/verify_function_not_present.sql
+++ b/schema/verify/util_functions/verify_function_not_present.sql
@@ -1,0 +1,7 @@
+-- Verify eed:util_functions/verify_function_not_present on pg
+
+begin;
+
+select pg_get_functiondef('eed_private.verify_function_not_present(text)'::regprocedure);
+
+rollback;


### PR DESCRIPTION
# Initialize Sqitch
Create roles `eed_internal`, `eed_external`, `eed_admin`, `eed_app`.
Create main schema `eed` and private schema `eed_private`.
Add util functions `grant_permissions` (1 for all permissions, 1 for select columns) and `verify_function_not_present`. 

Borrowed from CIF.