### PR TITLE
feat: terraform setup for provisioning cloudsql with pg db

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,7 +23,7 @@ provider "google-beta" {
 
 # create db instance
 resource "google_sql_database_instance" "postgresql" {
-  name                = "demo-db"
+  name                = var.db_name
   project             = var.project
   region              = var.region
   database_version    = var.db_version

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.35.0"
+      version = "3.60"
     }
   }
 }
@@ -13,4 +13,71 @@ provider "google" {
   project = var.project
   region  = var.region
   zone    = var.zone
+}
+
+provider "google-beta" {
+  project     = var.project
+  region      = var.region
+  credentials = file("gcp_sa_secret.json")
+}
+
+# create db instance
+resource "google_sql_database_instance" "postgresql" {
+  name             = "demo-db"
+  project          = var.project
+  region           = var.region
+  database_version = var.db_version
+  deletion_protection = false
+
+  settings {
+    tier              = var.db_tier
+    activation_policy = var.db_activation_policy
+    disk_autoresize   = var.db_disk_autoresize
+    disk_size         = var.db_disk_size
+    disk_type         = var.db_disk_type
+    pricing_plan      = var.db_pricing_plan
+
+    location_preference {
+      zone = var.zone
+    }
+
+    maintenance_window {
+      day  = "7" # sunday
+      hour = "3" # 3am
+    }
+
+    backup_configuration {
+      enabled            = true
+      start_time         = "00:00"
+    }
+
+    ip_configuration {
+      ipv4_enabled = "true"
+      authorized_networks {
+        value = var.db_instance_access_cidr
+      }
+    }
+  }
+}
+
+# create db
+resource "google_sql_database" "postgresql_db" {
+  name      = var.db_name
+  project   = var.project
+  instance  = google_sql_database_instance.postgresql.name
+  charset   = var.db_charset
+  collation = var.db_collation
+}
+
+# create user
+resource "random_id" "user_password" {
+  byte_length = 8
+}
+resource "google_sql_user" "postgresql_user" {
+  name     = var.db_user_name
+  project  = var.project
+  instance = google_sql_database_instance.postgresql.name
+  host     = var.db_user_host
+  password = (var.db_user_password == "" ?
+  random_id.user_password.hex : var.db_user_password)
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,10 +23,10 @@ provider "google-beta" {
 
 # create db instance
 resource "google_sql_database_instance" "postgresql" {
-  name             = "demo-db"
-  project          = var.project
-  region           = var.region
-  database_version = var.db_version
+  name                = "demo-db"
+  project             = var.project
+  region              = var.region
+  database_version    = var.db_version
   deletion_protection = false
 
   settings {
@@ -47,8 +47,8 @@ resource "google_sql_database_instance" "postgresql" {
     }
 
     backup_configuration {
-      enabled            = true
-      start_time         = "00:00"
+      enabled    = true
+      start_time = "00:00"
     }
 
     ip_configuration {

--- a/terraform/postgresql-instance-outputs.tf
+++ b/terraform/postgresql-instance-outputs.tf
@@ -1,0 +1,17 @@
+# Database output | postgresql-instance-output.tf
+output "db_instance_address" {
+  description = "IP address of the master database instance"
+  value       = google_sql_database_instance.postgresql.ip_address.0.ip_address
+}
+output "db_instance_name" {
+  description = "Name of the database instance"
+  value       = google_sql_database_instance.postgresql.name
+}
+output "db_instance_username" {
+  description = "Name of the database user"
+  value       = var.db_user_name
+}
+output "db_instance_generated_user_password" {
+  description = "The auto generated default user password if no input password was provided"
+  value       = random_id.user_password.hex
+}

--- a/terraform/postgresql-instance-variables.tf
+++ b/terraform/postgresql-instance-variables.tf
@@ -34,7 +34,7 @@ variable "db_instance_access_cidr" {
 # database settings
 variable "db_name" {
   description = "Name of the default database to create"
-  default     = "dem"
+  default     = "eed"
 }
 variable "db_charset" {
   description = "The charset for the default database"

--- a/terraform/postgresql-instance-variables.tf
+++ b/terraform/postgresql-instance-variables.tf
@@ -1,0 +1,59 @@
+# database instance settings
+variable "db_version" {
+  description = "The version of of the database."
+  default     = "POSTGRES_14"
+}
+variable "db_tier" {
+  description = "The machine tier (First Generation) or type (Second Generation). Reference: https://cloud.google.com/sql/pricing"
+  default     = "db-f1-micro"
+}
+variable "db_activation_policy" {
+  description = "Specifies when the instance should be active. Options are ALWAYS, NEVER or ON_DEMAND"
+  default     = "ALWAYS"
+}
+variable "db_disk_autoresize" {
+  description = "Second Generation only. Configuration to increase storage size automatically."
+  default     = true
+}
+variable "db_disk_size" {
+  description = "Second generation only. The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased."
+  default     = 10
+}
+variable "db_disk_type" {
+  description = "Second generation only. The type of data disk: PD_SSD or PD_HDD"
+  default     = "PD_SSD"
+}
+variable "db_pricing_plan" {
+  description = "First generation only. Pricing plan for this instance, can be one of PER_USE or PACKAGE"
+  default     = "PER_USE"
+}
+variable "db_instance_access_cidr" {
+  description = "The IPv4 CIDR to provide access the database instance"
+  default     = "0.0.0.0/0"
+}
+# database settings
+variable "db_name" {
+  description = "Name of the default database to create"
+  default     = "dem"
+}
+variable "db_charset" {
+  description = "The charset for the default database"
+  default     = ""
+}
+variable "db_collation" {
+  description = "The collation for the default database. Example for MySQL databases: 'utf8_general_ci'"
+  default     = ""
+}
+# user settings
+variable "db_user_name" {
+  description = "The name of the default user"
+  default     = "dbadmin"
+}
+variable "db_user_host" {
+  description = "The host for the default user"
+  default     = "%"
+}
+variable "db_user_password" {
+  description = "The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable."
+  default     = ""
+}


### PR DESCRIPTION
This provisions the following:
- google_sql_database_instance
- google_sql_database
- google_sql_user for the database