### PR TITLE
15 add new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,11 +7,6 @@ assignees: ''
 
 ---
 
----
-name: Feature request
-about: Suggest an idea for this project
----
-
 ### Description
 
 Specify which part of the system we're working in.

--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -1,0 +1,35 @@
+---
+name: Tech debt
+about: Record technical project debt
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Description
+A clear and concise description of what the tech debt is and the reason of being created
+
+### Impact
+Description of the current or future impact of this tech debt and the risks associated with leaving this debt unresolved.
+
+### Proposed Solution(s)
+##### Solution 1.
+| How | _______ |
+| :---: |  :---: |
+| Pros :green_heart: | _______ |
+| Cons :broken_heart: |  _______  |
+| Effort | SMALL / MEDIUM / LARGE |
+
+##### Solution 2.
+| How | _______ |
+| :---: |  :---: |
+| Pros :green_heart: | _______ |
+| Cons :broken_heart: |  _______  |
+| Effort | SMALL / MEDIUM / LARGE |
+
+
+### Acceptance Criteria
+| Given | When | Then | Pass/Fail (TBD by reviewer) |
+| :---  |:---: | ---: |---:                         |
+| `precondition/initial context/state of the system. Ex: I am an HTML only user` | `event/trigger. Ex: I receive an notification` |`output/action. Ex: I receive a closable notification` |   |

--- a/.github/ISSUE_TEMPLATE/user_story_template.md
+++ b/.github/ISSUE_TEMPLATE/user_story_template.md
@@ -1,0 +1,17 @@
+---
+name: User Story Template
+about: Template for new user stories
+title: ''
+labels: Story
+assignees: ''
+
+---
+
+### Description
+As a <user>
+I want <what>
+So that <this is important because ...>
+### Tasks (How)
+- [ ] Task
+- [ ] Task
+- [ ] Task


### PR DESCRIPTION
Added Github issue and tech debt templates matching those found in the service development toolkit repo. 

Note** A repository owner will need to configure the templates to be useable when creating new issues as per [this guide](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)