### PR TITLE
fix: use single default layout in app

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,12 +1,12 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
-import Layout from "components/layout";
+import DefaultLayout from "components/DefaultLayout";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
+    <DefaultLayout>
       <Component {...pageProps} />
-    </Layout>
+    </DefaultLayout>
   );
 }
 

--- a/app/pages/admin.tsx
+++ b/app/pages/admin.tsx
@@ -1,6 +1,5 @@
 import { Button, Grid } from "@button-inc/button-theme";
 import Link from "next/link";
-import DefaultLayout from "components/DefaultLayout";
 
 export default function Admin() {
   const adminOptions = [
@@ -11,25 +10,23 @@ export default function Admin() {
   ];
   return (
     <>
-      <DefaultLayout>
-        <Grid style={{ padding: "2rem" }}>
-          <Grid.Row justify="space-around" align="center">
-            {adminOptions.map((option) => (
-              <Grid.Col key={option.title} span="30">
-                <Link href={option.link}>
-                  <Button
-                    size="large"
-                    variant="secondary"
-                    style={{ width: "100%" }}
-                  >
-                    {option.title}
-                  </Button>
-                </Link>
-              </Grid.Col>
-            ))}
-          </Grid.Row>
-        </Grid>
-      </DefaultLayout>
+      <Grid style={{ padding: "2rem" }}>
+        <Grid.Row justify="space-around" align="center">
+          {adminOptions.map((option) => (
+            <Grid.Col key={option.title} span="30">
+              <Link href={option.link}>
+                <Button
+                  size="large"
+                  variant="secondary"
+                  style={{ width: "100%" }}
+                >
+                  {option.title}
+                </Button>
+              </Link>
+            </Grid.Col>
+          ))}
+        </Grid.Row>
+      </Grid>
     </>
   );
 }

--- a/app/pages/home.tsx
+++ b/app/pages/home.tsx
@@ -1,6 +1,5 @@
 import { Button, Grid } from "@button-inc/button-theme";
 import Link from "next/link";
-import DefaultLayout from "components/DefaultLayout";
 
 export default function Home() {
   const homeOptions = [
@@ -10,25 +9,23 @@ export default function Home() {
   ];
   return (
     <>
-      <DefaultLayout>
-        <Grid style={{ padding: "2rem" }}>
-          <Grid.Row justify="space-around" align="center">
-            {homeOptions.map((option) => (
-              <Grid.Col key={option.title} span="30">
-                <Link href={option.link}>
-                  <Button
-                    size="large"
-                    variant="secondary"
-                    style={{ width: "100%" }}
-                  >
-                    {option.title}
-                  </Button>
-                </Link>
-              </Grid.Col>
-            ))}
-          </Grid.Row>
-        </Grid>
-      </DefaultLayout>
+      <Grid style={{ padding: "2rem" }}>
+        <Grid.Row justify="space-around" align="center">
+          {homeOptions.map((option) => (
+            <Grid.Col key={option.title} span="30">
+              <Link href={option.link}>
+                <Button
+                  size="large"
+                  variant="secondary"
+                  style={{ width: "100%" }}
+                >
+                  {option.title}
+                </Button>
+              </Link>
+            </Grid.Col>
+          ))}
+        </Grid.Row>
+      </Grid>
     </>
   );
 }

--- a/app/pages/import.tsx
+++ b/app/pages/import.tsx
@@ -1,6 +1,5 @@
 import { Button, Grid } from "@button-inc/button-theme";
 import Link from "next/link";
-import DefaultLayout from "components/DefaultLayout";
 
 export default function Import() {
   const importOptions = [
@@ -10,25 +9,23 @@ export default function Import() {
   ];
   return (
     <>
-      <DefaultLayout>
-        <Grid style={{ padding: "2rem" }}>
-          <Grid.Row justify="space-around" align="center">
-            {importOptions.map((option) => (
-              <Grid.Col key={option.title} span="30">
-                <Link href={option.link}>
-                  <Button
-                    size="large"
-                    variant="secondary"
-                    style={{ width: "100%" }}
-                  >
-                    {option.title}
-                  </Button>
-                </Link>
-              </Grid.Col>
-            ))}
-          </Grid.Row>
-        </Grid>
-      </DefaultLayout>
+      <Grid style={{ padding: "2rem" }}>
+        <Grid.Row justify="space-around" align="center">
+          {importOptions.map((option) => (
+            <Grid.Col key={option.title} span="30">
+              <Link href={option.link}>
+                <Button
+                  size="large"
+                  variant="secondary"
+                  style={{ width: "100%" }}
+                >
+                  {option.title}
+                </Button>
+              </Link>
+            </Grid.Col>
+          ))}
+        </Grid.Row>
+      </Grid>
     </>
   );
 }

--- a/app/pages/insights.tsx
+++ b/app/pages/insights.tsx
@@ -1,6 +1,5 @@
 import { Button, Grid } from "@button-inc/button-theme";
 import Link from "next/link";
-import DefaultLayout from "components/DefaultLayout";
 
 export default function Insights() {
   const insightsOptions = [
@@ -9,25 +8,23 @@ export default function Insights() {
   ];
   return (
     <>
-      <DefaultLayout>
-        <Grid style={{ padding: "2rem" }}>
-          <Grid.Row justify="space-around" align="center">
-            {insightsOptions.map((option) => (
-              <Grid.Col key={option.title} span="30">
-                <Link href={option.link}>
-                  <Button
-                    size="large"
-                    variant="secondary"
-                    style={{ width: "100%" }}
-                  >
-                    {option.title}
-                  </Button>
-                </Link>
-              </Grid.Col>
-            ))}
-          </Grid.Row>
-        </Grid>
-      </DefaultLayout>
+      <Grid style={{ padding: "2rem" }}>
+        <Grid.Row justify="space-around" align="center">
+          {insightsOptions.map((option) => (
+            <Grid.Col key={option.title} span="30">
+              <Link href={option.link}>
+                <Button
+                  size="large"
+                  variant="secondary"
+                  style={{ width: "100%" }}
+                >
+                  {option.title}
+                </Button>
+              </Link>
+            </Grid.Col>
+          ))}
+        </Grid.Row>
+      </Grid>
     </>
   );
 }

--- a/app/pages/login.tsx
+++ b/app/pages/login.tsx
@@ -1,30 +1,27 @@
 import { Button, Grid } from "@button-inc/button-theme";
 import Link from "next/link";
-import DefaultLayout from "components/DefaultLayout";
 
 export default function Login() {
   const loginOptions = [{ title: "Log in", link: "home" }];
   return (
     <>
-      <DefaultLayout>
-        <Grid style={{ padding: "2rem" }}>
-          <Grid.Row justify="space-around" align="center">
-            {loginOptions.map((option) => (
-              <Grid.Col key={option.title} span="30">
-                <Link href={option.link}>
-                  <Button
-                    size="large"
-                    variant="secondary"
-                    style={{ width: "100%" }}
-                  >
-                    {option.title}
-                  </Button>
-                </Link>
-              </Grid.Col>
-            ))}
-          </Grid.Row>
-        </Grid>
-      </DefaultLayout>
+      <Grid style={{ padding: "2rem" }}>
+        <Grid.Row justify="space-around" align="center">
+          {loginOptions.map((option) => (
+            <Grid.Col key={option.title} span="30">
+              <Link href={option.link}>
+                <Button
+                  size="large"
+                  variant="secondary"
+                  style={{ width: "100%" }}
+                >
+                  {option.title}
+                </Button>
+              </Link>
+            </Grid.Col>
+          ))}
+        </Grid.Row>
+      </Grid>
     </>
   );
 }

--- a/app/pages/view.tsx
+++ b/app/pages/view.tsx
@@ -1,6 +1,5 @@
 import { Button, Grid } from "@button-inc/button-theme";
 import Link from "next/link";
-import DefaultLayout from "components/DefaultLayout";
 
 export default function View() {
   const viewOptions = [
@@ -10,25 +9,23 @@ export default function View() {
   ];
   return (
     <>
-      <DefaultLayout>
-        <Grid style={{ padding: "2rem" }}>
-          <Grid.Row justify="space-around" align="center">
-            {viewOptions.map((option) => (
-              <Grid.Col key={option.title} span="30">
-                <Link href={option.link}>
-                  <Button
-                    size="large"
-                    variant="secondary"
-                    style={{ width: "100%" }}
-                  >
-                    {option.title}
-                  </Button>
-                </Link>
-              </Grid.Col>
-            ))}
-          </Grid.Row>
-        </Grid>
-      </DefaultLayout>
+      <Grid style={{ padding: "2rem" }}>
+        <Grid.Row justify="space-around" align="center">
+          {viewOptions.map((option) => (
+            <Grid.Col key={option.title} span="30">
+              <Link href={option.link}>
+                <Button
+                  size="large"
+                  variant="secondary"
+                  style={{ width: "100%" }}
+                >
+                  {option.title}
+                </Button>
+              </Link>
+            </Grid.Col>
+          ))}
+        </Grid.Row>
+      </Grid>
     </>
   );
 }

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -30,7 +30,7 @@ a {
   align-items: center;
   justify-content: center;
   text-align: center;
-  min-height: 100vh;
+  min-height: 80vh;
 }
 
 .page-container {


### PR DESCRIPTION
This PR moves the `DefaultLayout` into the core app and out of the individual pages (it's used everywhere anyway). l It also addresses some oddness with the admin page. 