### PR TITLE
fix: change pre-commit to run prettier locally on commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,15 @@
+default_stages:
+  [
+    commit,
+    merge-commit,
+    push,
+    prepare-commit-msg,
+    post-checkout,
+    post-commit,
+    post-merge,
+    post-rewrite,
+    manual,
+  ]
 exclude: >
   (?x)^(
       test\.tsx\.snap$
@@ -9,7 +21,6 @@ repos:
         name: Prettier
         language: script
         entry: ./.bin/pre-commit-format.sh
-        stages: [commit]
   - repo: local
     hooks:
       - id: eslint
@@ -39,6 +50,7 @@ repos:
     rev: v0.17.0
     hooks:
       - id: gitlint
+        stages: [commit-msg]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v8.0.0
     hooks:

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,3 +3,4 @@ yarn 1.22.18
 postgres 14.1
 python 3.9.11
 terraform 1.2.9
+pre-commit 2.20.0

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ The list of what it is tracking can be found in `.gitattributes`, currently `ter
 To add to the tracked list, use
 `git lfs track <>` where <> could be `"*.someFileExtension"`, `path/to/dir/**` for an entire directory.
 
+## Tooling initialization
+
+### asdf
+
+[asdf](https://asdf-vm.com/) is used to maintain consistent software tooling for this repo. See [installation instructions here](https://asdf-vm.com/guide/getting-started.html).
+
+After cloning the repo, run `asdf install` to add any required software packages.
+
+### Pre-commit
+
+This repo uses [pre-commit](https://pre-commit.com/) to preform static analysis, code linting/formatting and more.
+
+After asdf has already been run to install pre-commit, run: `pre-commit install`.
+
+> If pre-commit hooks are not running (or are incomplete), try `pre-commit uninstall` and `pre-commit install` to refresh.
+
+### GitLint
+
+After pre-commit is installed, run `pre-commit install --hook-type commit-msg` to enable [gitlint](https://jorisroovers.com/gitlint/#using-gitlint-through-pre-commit)
+
 ## Terraform
 
 In order to run terraform plan etc. in this project, you currently need to ask for the credentials file. This will be dealt with properly shortly.


### PR DESCRIPTION
Adresses #102. Adds documentation for proper initialization of `pre-commit` scripts and ensures it runs properly on commit. 

## Changes

- Additional developer documentation in readme.
- `pre-commit`'s config changed so commit message-related steps are only run during that stage.

### Notes

I tested that GitHub actions still run as before by submitting a commit with formatting errors. Achieved by bypassing the local `pre-commit` actions with `--no-verify` when committing and pushing to GitHub. [Action run is here](https://github.com/button-inc/emissions-elt-demo/actions/runs/3634100377)

## Further info

With the way our `pre-commit` set of tools are used, on a commit, there are _two_ actions that are run. Once for `commit` and once for `commit-message`. Because the steps of `pre-commit` are set to run on every stage by default, it would cause all `pc` steps to run twice. This pulls out the two message related steps out to run only on the `commit-message` stage, while everything else defaults to running on all other stages (essentially, as close to default). 

> For best results, run the setup laid out in the `README.md` to uninstall and reinstall `pre-commit` and subsequent tools. This corrected issues in my own dev environment.