### PR TITLE
chore: modified roles and users table

### DIFF
--- a/schema/deploy/add_test_user.sql
+++ b/schema/deploy/add_test_user.sql
@@ -5,8 +5,7 @@ BEGIN;
 
 CREATE USER eed_test_user WITH LOGIN PASSWORD 'secret';
 
---GRANT eed_internal to eed_test_user;
-SELECT eed_private.insert_user('eed_test_user', 'secret', 'eed_test_user@button.is');
+GRANT eed_internal to eed_test_user;
 
 
 COMMIT;

--- a/schema/deploy/create-roles.sql
+++ b/schema/deploy/create-roles.sql
@@ -17,6 +17,8 @@ begin
     create role eed_internal;
   end if;
 
+  alter role eed_internal WITH LOGIN PASSWORD 'secret';
+
   if not exists (
     select true
     from   pg_catalog.pg_roles

--- a/schema/deploy/insert_user.sql
+++ b/schema/deploy/insert_user.sql
@@ -5,14 +5,12 @@ BEGIN;
 
 SET client_min_messages = 'warning';
 
-CREATE EXTENSION "uuid-ossp";
-
 CREATE OR REPLACE FUNCTION eed_private.insert_user(
     username varchar(1000),
-    password varchar(1000),
-    email varchar(1000)
+    email varchar(1000),
+    user_role varchar(1000)
 ) RETURNS VOID LANGUAGE SQL SECURITY DEFINER AS $$
-    INSERT INTO eed.users (uuid, username, password, email) VALUES((SELECT uuid_generate_v4()), $1, md5($2), $3);
+    INSERT INTO eed.users (username, email, user_role) VALUES($1, $2, $3);
 $$;
 
 COMMIT;

--- a/schema/deploy/users.sql
+++ b/schema/deploy/users.sql
@@ -7,14 +7,12 @@ SET client_min_messages = 'warning';
 -- Create users table
 CREATE TABLE eed.users (
     id integer primary key generated always as identity,
-    uuid uuid not null,
     username varchar(1000) not null,
-    password varchar(1000) not null,
-    email varchar(1000)
+    email varchar(1000),
+    user_role varchar(1000)
 );
 
 -- Create unique index to enforce uniqueness constraint on fields
-create unique index eed_user_uuid on eed.users(uuid);
 create unique index eed_user_username on eed.users(username);
 
 -- Grant permissions for each table to roles. args = (permission, table, role). eed_app has the combined permissions of these roles.
@@ -41,9 +39,8 @@ alter table eed.users enable row level security;
 
 comment on table eed.users is 'Table containing information about application users';
 comment on column eed.users.id is 'Unique ID for the user';
-comment on column eed.users.uuid is 'Universally unique ID for the user, defined by the single sign-on provider';
 comment on column eed.users.username is 'Unique username';
-comment on column eed.users.password is 'Password hashed with md5';
 comment on column eed.users.email is 'Email account associated with user';
+comment on column eed.users.user_role is 'Role determines user permissions';
 
 COMMIT;

--- a/schema/revert/insert_user.sql
+++ b/schema/revert/insert_user.sql
@@ -4,6 +4,4 @@ BEGIN;
 
 DROP FUNCTION eed_private.insert_user(varchar(1000), varchar(1000), varchar(1000));
 
-DROP EXTENSION "uuid-ossp";
-
 COMMIT;

--- a/schema/verify/add_test_user.sql
+++ b/schema/verify/add_test_user.sql
@@ -5,7 +5,4 @@ BEGIN;
 -- Check that the eed_test_user user has been created
 SELECT 1 FROM pg_user WHERE usename = 'eed_test_user';
 
--- Check that the eed_private.insert_user function was called for the eed_test_user user
-SELECT 1 FROM eed.users WHERE username = 'eed_test_user';
-
 ROLLBACK;

--- a/schema/verify/insert_user.sql
+++ b/schema/verify/insert_user.sql
@@ -4,6 +4,4 @@ BEGIN;
 
 SELECT has_function_privilege('eed_private.insert_user(varchar(1000), varchar(1000), varchar(1000))', 'execute');
 
-SELECT extname FROM pg_extension WHERE extname = 'uuid-ossp';
-
 ROLLBACK;


### PR DESCRIPTION
Modified db with following changes:

No longer add eed_test_user to users table

Add password and login to eed_internal so it can be used in conn string

Change users table: it should have username, email, and role. No need for password.