### PR TITLE
feat: Insights ingestion tables

### DIFF
--- a/schema/deploy/tables/import_record.sql
+++ b/schema/deploy/tables/import_record.sql
@@ -1,0 +1,18 @@
+-- Deploy eed:tables/import_record to pg
+
+BEGIN;
+
+create table eed.track_format(
+  id SERIAL PRIMARY KEY,
+  nickname TEXT not null
+);
+
+create table eed.import_record(
+  job_id SERIAL PRIMARY KEY,
+  file_name TEXT not null,
+  uploaded_by_user_id INTEGER REFERENCES eed.users(id),
+  track_format_id INTEGER REFERENCES eed.track_format(id),
+  submission_date TIMESTAMP not null DEFAULT NOW()
+);
+
+COMMIT;

--- a/schema/deploy/tables/insight-destination-processed.sql
+++ b/schema/deploy/tables/insight-destination-processed.sql
@@ -1,0 +1,30 @@
+-- Deploy eed:tables/insight-destination-processed to pg
+
+BEGIN;
+
+create table eed.study_area(
+  study_area_id SERIAL PRIMARY KEY,
+  area_name TEXT not null,
+  updated_at TIMESTAMP not null DEFAULT NOW(),
+  UNIQUE (area_name)
+);
+
+-- Primary key is a pair of (origin_area_id, destination_area_id)
+create table eed.insights_voyage(
+  origin_area_id INTEGER REFERENCES eed.study_area(study_area_id),
+  destination_area_id INTEGER REFERENCES eed.study_area(study_area_id),
+  voyage_count INTEGER not null CHECK (voyage_count >= 0),
+  start_time TIMESTAMP not null,
+  updated_at TIMESTAMP not null DEFAULT NOW(),
+  PRIMARY KEY (origin_area_id, destination_area_id)
+);
+
+create table eed.area_distance_map(
+  origin_area_id INTEGER REFERENCES eed.study_area(study_area_id),
+  destination_area_id INTEGER REFERENCES eed.study_area(study_area_id),
+  distance INTEGER not null CHECK (distance >= 0),
+  updated_at TIMESTAMP not null DEFAULT NOW(),
+  PRIMARY KEY (origin_area_id, destination_area_id)
+);
+
+COMMIT;

--- a/schema/revert/tables/import_record.sql
+++ b/schema/revert/tables/import_record.sql
@@ -1,0 +1,8 @@
+-- Revert eed:tables/import_record from pg
+
+BEGIN;
+
+drop table eed.import_record;
+drop table eed.track_format;
+
+COMMIT;

--- a/schema/revert/tables/insight-destination-processed.sql
+++ b/schema/revert/tables/insight-destination-processed.sql
@@ -1,0 +1,9 @@
+-- Revert eed:tables/insight-destination-processed from pg
+
+BEGIN;
+
+drop table eed.area_distance_map;
+drop table eed.insights_voyage;
+drop table eed.study_area;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -14,3 +14,4 @@ change_password [users] 2022-12-21T17:40:37Z Ballard Robinett,,, <ballardrobinet
 add_table 2022-12-22T17:15:28Z Ballard Robinett,,, <ballardrobinett@system76-pc> # Add a table.
 verify_grant 2022-12-23T05:52:10Z Ballard Robinett,,, <ballardrobinett@system76-pc> # Verify that roles have been granted privileges.
 add_test_user 2022-12-23T20:24:40Z Ballard Robinett,,, <ballardrobinett@system76-pc> # Add a user to test login and permissions.
+tables/import_record 2022-12-15T22:13:38Z Josh Gamache <joshua@button.is> # table for the record of data submissions

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -15,3 +15,4 @@ add_table 2022-12-22T17:15:28Z Ballard Robinett,,, <ballardrobinett@system76-pc>
 verify_grant 2022-12-23T05:52:10Z Ballard Robinett,,, <ballardrobinett@system76-pc> # Verify that roles have been granted privileges.
 add_test_user 2022-12-23T20:24:40Z Ballard Robinett,,, <ballardrobinett@system76-pc> # Add a user to test login and permissions.
 tables/import_record 2022-12-15T22:13:38Z Josh Gamache <joshua@button.is> # table for the record of data submissions
+tables/insight-destination-processed 2022-12-19T21:56:29Z Josh Gamache <joshua@button.is> # tables for processed Insights/Destination API data

--- a/schema/verify/tables/import_record.sql
+++ b/schema/verify/tables/import_record.sql
@@ -1,0 +1,14 @@
+-- Verify eed:tables/import_record on pg
+
+BEGIN;
+
+select id, nickname
+  from eed.track_format
+  where false;
+
+select job_id, file_name, uploaded_by_user_id, track_format_id, submission_date
+  from eed.import_record
+  where false;
+
+
+ROLLBACK;

--- a/schema/verify/tables/insight-destination-processed.sql
+++ b/schema/verify/tables/insight-destination-processed.sql
@@ -1,0 +1,17 @@
+-- Verify eed:tables/insight-destination-processed on pg
+
+BEGIN;
+
+select study_area_id, area_name, updated_at
+  from eed.study_area
+  where false;
+
+select origin_area_id, destination_area_id, voyage_count, start_time, updated_at
+  from eed.insights_voyage
+  where false;
+
+select origin_area_id, destination_area_id, distance, updated_at
+  from eed.area_distance_map
+  where false;
+
+ROLLBACK;


### PR DESCRIPTION
Addresses #121. Adds tables to handle data to be extracted from the Telus Insights API.

## Changes

- Added task to Sqitch plan to add table for import_record (a record of the imported file) and its track_format (how to process the data, that is its "data connector")
- Added task to Sqitch plan to add table for study_area (matching study areas from Insights), insights_voyage (core origin to destination counts from Insights) and area_distance_map (distance between to areas, which will come from the hex tesselation)
