### PR TITLE
fix: remove extra spaces from template (pre-commit error)

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_story_template.md
+++ b/.github/ISSUE_TEMPLATE/user_story_template.md
@@ -7,15 +7,15 @@ assignees: ''
 
 ---
 
-As a 
-I want 
-so that 
+As a
+I want
+so that
 
 ## Acceptance Criteria:
-- [ ] 
-- [ ] 
-- [ ] 
-- [ ] 
+- [ ]
+- [ ]
+- [ ]
+- [ ]
 
 ## Not included:
 -


### PR DESCRIPTION
Fixes `pre-commit` errors thrown due to trailing whitespace in updated Issue Template