### PR TITLE
chore: add sqitch plan for PostGIS extension

### DIFF
--- a/schema/deploy/postgis_extension.sql
+++ b/schema/deploy/postgis_extension.sql
@@ -1,0 +1,7 @@
+-- Deploy eed:postgis_extension to pg
+
+BEGIN;
+
+CREATE EXTENSION if not exists postgis;
+
+COMMIT;

--- a/schema/revert/postgis_extension.sql
+++ b/schema/revert/postgis_extension.sql
@@ -1,0 +1,7 @@
+-- Revert eed:postgis_extension from pg
+
+BEGIN;
+
+DROP EXTENSION postgis CASCADE;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -17,3 +17,4 @@ add_test_user 2022-12-23T20:24:40Z Ballard Robinett,,, <ballardrobinett@system76
 tables/import_record 2022-12-15T22:13:38Z Josh Gamache <joshua@button.is> # table for the record of data submissions
 tables/insight-destination-processed 2022-12-19T21:56:29Z Josh Gamache <joshua@button.is> # tables for processed Insights/Destination API data
 add_users 2023-01-10T16:44:08Z eed_test_user <eed_test_user@button.is> # Add default users to db
+postgis_extension 2023-01-06T21:21:20Z Josh Gamache <joshua@button.is> # enable postGIS extension, allowing geospacial data to be utilized

--- a/schema/verify/postgis_extension.sql
+++ b/schema/verify/postgis_extension.sql
@@ -1,0 +1,14 @@
+-- Verify eed:postgis_extension on pg
+
+BEGIN;
+
+SELECT 1/count(*) FROM pg_extension WHERE extname = 'postgis';
+do $$
+  begin
+    assert (
+      select true from pg_catalog.pg_type where typname = 'geometry'
+    ), 'type "geometry" is not defined, therefore PostGIS extension is not active';
+  end;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
Closes #137 . Enables the PostGIS extension in Postgres using a Sqitch plan.

## Changes

- Add sqitch step to enable PostGIS

### Notes

PostGIS is [available within GCP Cloud SQL](https://cloud.google.com/sql/docs/postgres/extensions#postgis), so the extension can be enabled using Sqitch.