### PR TITLE
chore: add ids in two forms to insights_voyage table

### DIFF
--- a/schema/deploy/computed_columns/voyage_combined_id.sql
+++ b/schema/deploy/computed_columns/voyage_combined_id.sql
@@ -1,0 +1,15 @@
+-- Deploy eed:computed_columns/voyage_combined_id to pg
+
+BEGIN;
+
+create or replace function data_science_workspace.insights_voyage_voyage_id(iv data_science_workspace.insights_voyage)
+returns varchar as $computed_column$
+  select iv.origin_area_id || '_' || iv.destination_area_id;
+$computed_column$ language sql stable;
+
+grant execute on function data_science_workspace.insights_voyage_voyage_id to eed_internal, eed_external, eed_admin;
+grant execute on function data_science_workspace.insights_voyage_voyage_id to analyst, manager;
+
+comment on function data_science_workspace.insights_voyage_voyage_id is 'Computed column for postgraphile to retrieve the id pair of the insights voyage';
+
+COMMIT;

--- a/schema/deploy/tables/add_id_to_insights_voyage.sql
+++ b/schema/deploy/tables/add_id_to_insights_voyage.sql
@@ -1,0 +1,9 @@
+-- Deploy eed:tables/add_id_to_insights_voyage to pg
+-- requires: tables/insight-destination-processed@alpha-23-01-18
+
+BEGIN;
+
+ALTER TABLE if exists data_science_workspace.insights_voyage
+  ADD COLUMN IF NOT EXISTS id SERIAL;
+
+COMMIT;

--- a/schema/revert/computed_columns/voyage_combined_id.sql
+++ b/schema/revert/computed_columns/voyage_combined_id.sql
@@ -1,0 +1,7 @@
+-- Revert eed:computed_columns/voyage_combined_id from pg
+
+BEGIN;
+
+drop function data_science_workspace.insights_voyage_voyage_id;
+
+COMMIT;

--- a/schema/revert/tables/add_id_to_insights_voyage.sql
+++ b/schema/revert/tables/add_id_to_insights_voyage.sql
@@ -1,0 +1,8 @@
+-- Revert eed:tables/add_id_to_insights_voyage from pg
+
+BEGIN;
+
+ALTER TABLE if exists data_science_workspace.insights_voyage
+  DROP COLUMN IF EXISTS id;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -21,3 +21,4 @@ tables/insight-destination-processed [tables/insight-destination-processed@alpha
 tables/import_record [tables/import_record@alpha-23-01-18 add_data_schemas] 2023-01-18T17:11:51Z Josh Gamache <joshua@button.is> # Change import tables to use new schema
 tables/study_area_geometry 2023-01-19T17:00:50Z Josh Gamache <joshua@button.is> # Add table for study area hexes
 tables/add_id_to_insights_voyage [tables/insight-destination-processed@alpha-23-01-18] 2023-01-20T17:20:26Z Josh Gamache <joshua@button.is> # Adds an additional id column to insights voyage table
+computed_columns/voyage_combined_id 2023-01-20T17:57:07Z Josh Gamache <joshua@button.is> # Add computed column for insights_voyage table combining origing_id and destination_id

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -20,3 +20,4 @@ add_data_schemas 2023-01-17T02:37:23Z eed_test_user <eed_test_user@button.is> # 
 tables/insight-destination-processed [tables/insight-destination-processed@alpha-23-01-18 add_data_schemas] 2023-01-18T16:33:57Z Josh Gamache <joshua@button.is> # Change insights tables to use new schema
 tables/import_record [tables/import_record@alpha-23-01-18 add_data_schemas] 2023-01-18T17:11:51Z Josh Gamache <joshua@button.is> # Change import tables to use new schema
 tables/study_area_geometry 2023-01-19T17:00:50Z Josh Gamache <joshua@button.is> # Add table for study area hexes
+tables/add_id_to_insights_voyage [tables/insight-destination-processed@alpha-23-01-18] 2023-01-20T17:20:26Z Josh Gamache <joshua@button.is> # Adds an additional id column to insights voyage table

--- a/schema/verify/computed_columns/voyage_combined_id.sql
+++ b/schema/verify/computed_columns/voyage_combined_id.sql
@@ -1,0 +1,7 @@
+-- Verify eed:computed_columns/voyage_combined_id on pg
+
+BEGIN;
+
+select pg_get_functiondef('data_science_workspace.insights_voyage_voyage_id(data_science_workspace.insights_voyage)'::regprocedure);
+
+ROLLBACK;

--- a/schema/verify/tables/add_id_to_insights_voyage.sql
+++ b/schema/verify/tables/add_id_to_insights_voyage.sql
@@ -1,0 +1,9 @@
+-- Verify eed:tables/add_id_to_insights_voyage on pg
+
+BEGIN;
+
+select id
+  from data_science_workspace.insights_voyage
+  where false;
+
+ROLLBACK;


### PR DESCRIPTION
Adds IDs to the insights voyage table for improved Postgraphile queries. 

## Changes

- Adds serial ID
- Adds computed column for `{origin_area_id}-{destination_area_id}`