### PR TITLE
feat: add Waste & Building tables and data ingestion dags

### DIFF
--- a/dags/sample-building-ingestion-dag.py
+++ b/dags/sample-building-ingestion-dag.py
@@ -1,0 +1,187 @@
+import os
+import csv
+import psycopg2
+from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
+from datetime import timedelta
+from google.cloud import storage
+from airflow.models import DAG
+
+
+default_args = {
+  'email': ['joshua@button.is'],
+  'email_on_retry': False,
+  'email_on_failure': False,
+  'retries': 1,
+  'retry_delay': timedelta(minutes=5),
+  'depends_on_past': False,
+  'start_date': days_ago(1),
+}
+
+csv_building_area_filename = "bc_building_data.csv"
+csv_occupancy_filename = "9810003801-eng_bc_municipal.csv"
+
+def import_raw_building_data_and_upsert_to_db():
+  conn = psycopg2.connect(database="eed",
+              user=os.environ['eed_db_user'], password=os.environ['eed_db_pass'],
+              host=os.environ['eed_db_host'], port='5432'
+  )
+
+  conn.autocommit = False
+  cursor = conn.cursor()
+
+  client = storage.Client()
+  bucket = client.get_bucket('eed-dag-test-bucket')
+  blob = bucket.get_blob(csv_building_area_filename)
+  downloaded_blob = blob.download_as_text()
+
+  with open('temp.csv', 'w') as f:
+    f.write(downloaded_blob)
+
+  with open('temp.csv', 'r', newline='') as f:
+    building_csv = csv.reader(f, delimiter=';')
+    headers = next(building_csv)
+    print(headers)
+    for row in building_csv:
+      [id, longitude, latitude, csduid, csdname, data_prov, build_id, shape_length, shape_footprint_area] = row;
+      cursor.execute(
+        f"INSERT INTO data_clean_room.buildings(longitude, latitude, csduid, csdname, data_prov, build_id, shape_length, shape_footprint_area) "
+        f"VALUES (%s, %s, %s, %s, %s, %s, %s, %s)"
+        f"ON CONFLICT (build_id) DO NOTHING",
+        (longitude, latitude, csduid, csdname, data_prov, build_id, shape_length, shape_footprint_area)
+      )
+
+  os.remove('temp.csv')
+
+  conn.commit()
+  conn.close()
+
+def import_raw_population_data_and_upsert_to_db():
+  conn = psycopg2.connect(database="eed",
+              user=os.environ['eed_db_user'], password=os.environ['eed_db_pass'],
+              host=os.environ['eed_db_host'], port='5432'
+  )
+
+  conn.autocommit = False
+  cursor = conn.cursor()
+
+  client = storage.Client()
+  bucket = client.get_bucket('eed-dag-test-bucket')
+  blob = bucket.get_blob(csv_occupancy_filename)
+  downloaded_blob = blob.download_as_text()
+
+  with open('temp.csv', 'w') as f:
+    f.write(downloaded_blob)
+
+  with open('temp.csv', 'r', newline='') as f:
+    header_lines = 11 # dwelling population data contains metadata as above the header
+    building_csv = csv.reader(f)
+    ref_date = 2021;
+
+    for i in range(header_lines):
+      headers = next(building_csv)
+      print(headers)
+
+    print("=== Start of data to insert into database ===")
+    for row in building_csv:
+      if not row:
+        print("=== End of data to insert into database ===")
+        break
+      [geo_name, dwell_occupied, pop_in_dwellings] = row;
+      print(f"Geographic designation: {geo_name} | Dwellings: {dwell_occupied} | Population in dwellings: {pop_in_dwellings}")
+      cursor.execute(
+        f"INSERT INTO data_clean_room.dwelling_populations(reference_date, geographic_location, dwellings_occupied_by_usual_residents, population_in_dwellings) "
+        f"VALUES (%s, %s, %s, %s)"
+        f"ON CONFLICT (reference_date, geographic_location) DO NOTHING",
+        (ref_date, geo_name, dwell_occupied.replace(",", ""), pop_in_dwellings.replace(",", ""))
+      )
+
+    for footer in building_csv:
+      print(footer)
+
+  os.remove('temp.csv')
+
+  conn.commit()
+  conn.close()
+
+def load_density_data_to_workspace_db():
+  conn = psycopg2.connect(database="eed",
+              user=os.environ['eed_db_user'], password=os.environ['eed_db_pass'],
+              host=os.environ['eed_db_host'], port='5432'
+  )
+
+  conn.autocommit = False
+  cursor = conn.cursor()
+
+
+  print("Loading density data from Data Clean Room into Data Science Workspace")
+  cursor.execute(
+    f"insert into data_science_workspace.building_populations(reference_date, municipal_name, dwellings_occupied_by_usual_residents, population_in_dwellings) "
+    f"select dp.reference_date, md.id, dp.dwellings_occupied_by_usual_residents, dp.population_in_dwellings "
+    f"from data_clean_room.dwelling_populations as dp "
+    f"join data_science_workspace.municipal_district as md "
+    f"on dp.geographic_location ~* md.municipal_abbreviated_name "
+    f"on conflict (reference_date, municipal_name) DO NOTHING"
+    )
+
+  conn.commit()
+  conn.close()
+
+def transform_load_building_data_to_workspace_db():
+  conn = psycopg2.connect(database="eed",
+              user=os.environ['eed_db_user'], password=os.environ['eed_db_pass'],
+              host=os.environ['eed_db_host'], port='5432'
+  )
+
+  conn.autocommit = False
+  cursor = conn.cursor()
+
+
+  print("Loading building footprint data from Data Clean Room into Data Science Workspace")
+  cursor.execute(
+    f"insert into data_science_workspace.MUNICIPAL_BUILDING(municipal_name, TOTAL_BUILDINGS, TOTAL_BUILDING_AREA) "
+    f"select md.id, sum(builds.building_count), sum(builds.SUM_FOOTPRINT) "
+    f"from (select csdname, count(csdname) as building_count, sum(b.SHAPE_FOOTPRINT_AREA) as sum_footprint "
+    f"from data_clean_room.buildings b "
+    f"group by csdname) as builds "
+    f"join data_science_workspace.municipal_district md "
+    f"on builds.csdname ~* md.municipal_abbreviated_name "
+    f"group by md.id "
+    f"on conflict (municipal_name) DO NOTHING"
+    )
+
+  conn.commit()
+  conn.close()
+
+dag = DAG(
+  'IMPORT_building_csv_to_SQL',
+  default_args=default_args,
+  description='A DAG that imports municipal building and population csvs to an SQL database.',
+  schedule_interval=None,
+)
+
+building_csv = PythonOperator(
+        task_id='municipal_building_raw_ingestion',
+        python_callable=import_raw_building_data_and_upsert_to_db,
+        dag=dag,
+)
+
+population_csv = PythonOperator(
+        task_id='import_raw_population_data_and_upsert_to_db',
+        python_callable=import_raw_population_data_and_upsert_to_db,
+        dag=dag,
+)
+
+load_density_data = PythonOperator(
+        task_id='load_density_data_to_workspace_db',
+        python_callable=load_density_data_to_workspace_db,
+        dag=dag,
+)
+
+load_building_data = PythonOperator(
+        task_id='transform_load_building_data_to_workspace_db',
+        python_callable=transform_load_building_data_to_workspace_db,
+        dag=dag,
+)
+
+building_csv >> population_csv >> load_density_data >> load_building_data

--- a/dags/sample-geospacial-db-ingestion-dag.py
+++ b/dags/sample-geospacial-db-ingestion-dag.py
@@ -55,7 +55,7 @@ def import_csv_and_upsert_to_db():
       cursor.execute(
         f"INSERT INTO data_science_workspace.study_area_geometry(area_name, hex_geometry) "
         f"VALUES (%(area_name)s, %(geometry)s) "
-        f"ON CONFLICT (area_name) DO UPDATE SET updated_at = NOW(), hex_geometry = %(geometry)s",
+        f"ON CONFLICT (area_name) DO UPDATE SET hex_geometry = %(geometry)s",
         {"area_name": row[0], "geometry": row[1]}
       )
   os.remove('temp.csv')

--- a/dags/sample-geospacial-db-ingestion-dag.py
+++ b/dags/sample-geospacial-db-ingestion-dag.py
@@ -58,6 +58,7 @@ def import_csv_and_upsert_to_db():
         f"ON CONFLICT (area_name) DO UPDATE SET updated_at = NOW(), hex_geometry = %(geometry)s",
         {"area_name": row[0], "geometry": row[1]}
       )
+  os.remove('temp.csv')
 
   conn.commit()
   conn.close()

--- a/dags/sample-waste-data-ingestion-dag.py
+++ b/dags/sample-waste-data-ingestion-dag.py
@@ -1,0 +1,179 @@
+import os
+import csv
+import psycopg2
+import geojson
+import json
+from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
+from datetime import timedelta
+from google.cloud import storage
+from airflow.models import DAG
+
+
+default_args = {
+  'email': ['joshua@button.is'],
+  'email_on_retry': False,
+  'email_on_failure': False,
+  'retries': 1,
+  'retry_delay': timedelta(minutes=5),
+  'depends_on_past': False,
+  'start_date': days_ago(1),
+}
+
+geojson_regional_geospatial_filename = 'regional_district_shapes.geojson'
+geojson_municipal_geospatial_filename = 'municipal_district_shapes.geojson'
+csv_waste_records_filename = 'bc_municipal_solid_waste_disposal.csv'
+
+def import_regional_geospatial_and_upsert_to_db():
+  conn = psycopg2.connect(database="eed",
+              user=os.environ['eed_db_user'], password=os.environ['eed_db_pass'],
+              host=os.environ['eed_db_host'], port='5432'
+  )
+
+  conn.autocommit = True
+  cursor = conn.cursor()
+
+  client = storage.Client()
+  bucket = client.get_bucket('eed-dag-test-bucket')
+  blob = bucket.get_blob(geojson_regional_geospatial_filename)
+  downloaded_blob = blob.download_as_bytes()
+
+  geojson_data = geojson.loads(downloaded_blob)
+
+  for feature in geojson_data.get("features"):
+    district_name = feature.get("properties", {}).get("ADMIN_AREA_NAME")
+    geometry = (json.dumps(feature['geometry']))
+    print(district_name)
+    print(geometry)
+    cursor.execute(
+        f"INSERT INTO data_science_workspace.regional_district(district_shape, district_name) "
+        f"VALUES ((ST_MULTI(ST_SetSRID(ST_GeomFromGeoJSON(%(geometry)s), 3005))), %(district_name)s) "
+        f"ON CONFLICT (district_name) DO NOTHING",
+        {"geometry": geometry, "district_name": district_name}
+    )
+
+  conn.commit()
+  conn.close()
+
+def import_municipal_geospatial_and_upsert_to_db():
+  conn = psycopg2.connect(database="eed",
+              user=os.environ['eed_db_user'], password=os.environ['eed_db_pass'],
+              host=os.environ['eed_db_host'], port='5432'
+  )
+
+  conn.autocommit = True
+  cursor = conn.cursor()
+
+  client = storage.Client()
+  bucket = client.get_bucket('eed-dag-test-bucket')
+  blob = bucket.get_blob(geojson_municipal_geospatial_filename)
+  downloaded_blob = blob.download_as_bytes()
+
+  geojson_data = geojson.loads(downloaded_blob)
+
+  for feature in geojson_data.get("features"):
+    region_name = feature.get("properties", {}).get("ADMIN_AREA_GROUP_NAME")
+    legal_name = feature.get("properties", {}).get("ADMIN_AREA_NAME")
+    abbr_name = feature.get("properties", {}).get("ADMIN_AREA_ABBREVIATION")
+    geometry = (json.dumps(feature['geometry']))
+    print(legal_name)
+    print(geometry)
+    cursor.execute(
+        f"INSERT INTO data_science_workspace.municipal_district(municipal_shape, municipal_legal_name, municipal_abbreviated_name, regional_district) "
+        f"VALUES ((ST_MULTI(ST_SetSRID(ST_GeomFromGeoJSON(%(geometry)s), 3005))), %(legal_name)s, %(abbr_name)s, (SELECT id from data_science_workspace.regional_district WHERE district_name=%(region)s)) "
+        f"ON CONFLICT (municipal_legal_name) DO NOTHING",
+        {"geometry": geometry, "legal_name": legal_name, "abbr_name": abbr_name, "region": region_name}
+    )
+
+  conn.commit()
+  conn.close()
+
+def import_regional_waste_data_and_upsert_to_clean_db():
+  conn = psycopg2.connect(database="eed",
+              user=os.environ['eed_db_user'], password=os.environ['eed_db_pass'],
+              host=os.environ['eed_db_host'], port='5432'
+  )
+
+  conn.autocommit = True
+  cursor = conn.cursor()
+
+  client = storage.Client()
+  bucket = client.get_bucket('eed-dag-test-bucket')
+  blob = bucket.get_blob(csv_waste_records_filename)
+  downloaded_blob = blob.download_as_text()
+
+  with open('temp.csv', 'w') as f:
+    f.write(downloaded_blob)
+  fr = open("temp.csv", "r")
+  print(fr.read())
+
+  with open('temp.csv', 'r', newline='') as f:
+    waste_csv = csv.reader(f)
+    headers = next(waste_csv)
+    print(headers)
+    for row in waste_csv:
+      cursor.execute(
+        f"INSERT INTO data_clean_room.raw_regional_waste_data(regional_district_name, reporting_year, total_disposed_tonnes, population_count, disposal_rate_kg) "
+        f"VALUES (%(region)s, %(year)s, NULLIF(%(disposed)s, '')::DECIMAL, NULLIF(%(pop)s, '')::integer,  NULLIF(%(rate_kg)s, '')::DECIMAL ) "
+        f"ON CONFLICT (regional_district_name, reporting_year) DO NOTHING",
+        {"region": row[0], "year": row[1], "disposed": row[2], "pop": row[3], "rate_kg": row[4]}
+      )
+  os.remove('temp.csv')
+
+  conn.commit()
+  conn.close()
+
+def transform_load_waste_data_to_workspace_db():
+  conn = psycopg2.connect(database="eed",
+              user=os.environ['eed_db_user'], password=os.environ['eed_db_pass'],
+              host=os.environ['eed_db_host'], port='5432'
+  )
+
+  conn.autocommit = False
+  cursor = conn.cursor()
+
+  print("Loading waste data from Data Clean Room into Data Science Workspace")
+  cursor.execute(
+    f"insert into data_science_workspace.regional_waste_data(regional_district, year, total_disposed_tonnes, population_count) "
+    f"select rd.id, rrwd.reporting_year, rrwd.total_disposed_tonnes, rrwd.population_count "
+    f"from data_clean_room.raw_regional_waste_data as rrwd "
+    f"join data_science_workspace.regional_district as rd "
+    f"on rd.district_name ~* replace(replace(rrwd.regional_district_name, 'comox-strathcona', 'strathcona'), '-', '.') " # TODO: Comox-Strathcona is a reports as a combined region
+    f"ON CONFLICT (regional_district, year) DO NOTHING"
+    )
+
+  conn.commit()
+  conn.close()
+
+dag = DAG(
+  'IMPORT_geo_waste_csv_to_SQL',
+  default_args=default_args,
+  description='A DAG that imports geospatial region, municipal, and waste csvs to an SQL database.',
+  schedule_interval=None,
+)
+
+region_csv = PythonOperator(
+        task_id='regional_geospacial_db_ingestion',
+        python_callable=import_regional_geospatial_and_upsert_to_db,
+        dag=dag,
+)
+
+municipal_csv = PythonOperator(
+        task_id='municipal_geospacial_db_ingestion',
+        python_callable=import_municipal_geospatial_and_upsert_to_db,
+        dag=dag,
+)
+
+waste_csv = PythonOperator(
+        task_id='waste_db_ingestion',
+        python_callable=import_regional_waste_data_and_upsert_to_clean_db,
+        dag=dag,
+)
+
+dsw_waste = PythonOperator(
+        task_id='transform_load_waste_data_to_workspace_db',
+        python_callable=transform_load_waste_data_to_workspace_db,
+        dag=dag,
+)
+
+region_csv >> municipal_csv >> waste_csv >> dsw_waste

--- a/schema/deploy/tables/building_data.sql
+++ b/schema/deploy/tables/building_data.sql
@@ -1,0 +1,48 @@
+-- Deploy eed:tables/building_data to pg
+
+BEGIN;
+
+create table if not exists data_clean_room.dwelling_populations(
+  id SERIAL PRIMARY KEY,
+  reference_date INTEGER default 2021,
+  geographic_location TEXT not null,
+  dwellings_occupied_by_usual_residents INTEGER,
+  population_in_dwellings INTEGER
+);
+
+create table if not exists data_science_workspace.building_populations(
+  id SERIAL PRIMARY KEY,
+  reference_date INTEGER default 2021,
+  municipal_name TEXT not null,
+  dwellings_occupied_by_usual_residents INTEGER,
+  population_in_dwellings INTEGER
+);
+
+create table if not exists data_clean_room.buildings(
+  id SERIAL PRIMARY KEY,
+  longitude decimal,
+  latitude decimal,
+  csduid text,
+  csdname text,
+  data_prov text,
+  build_id text,
+  shape_length decimal,
+  shape_footprint_area decimal
+);
+
+create table if not exists data_science_workspace.municipal_building(
+  id SERIAL primary key,
+  municipal_name text not null,
+  total_buildings integer,
+  total_building_area decimal,
+  UNIQUE (municipal_name)
+);
+
+-- dev roles
+grant all on data_clean_room.dwelling_populations, data_clean_room.buildings, data_science_workspace.municipal_building to eed_internal, eed_external, eed_admin;
+-- -- analyst
+grant all on data_clean_room.dwelling_populations, data_clean_room.buildings, data_science_workspace.municipal_building to analyst;
+-- manager
+grant all on data_clean_room.dwelling_populations, data_science_workspace.municipal_building to manager;
+
+COMMIT;

--- a/schema/deploy/tables/building_data.sql
+++ b/schema/deploy/tables/building_data.sql
@@ -4,35 +4,38 @@ BEGIN;
 
 create table if not exists data_clean_room.dwelling_populations(
   id SERIAL PRIMARY KEY,
-  reference_date INTEGER default 2021,
+  reference_date INTEGER not null,
   geographic_location TEXT not null,
   dwellings_occupied_by_usual_residents INTEGER,
-  population_in_dwellings INTEGER
+  population_in_dwellings INTEGER,
+  UNIQUE(reference_date,geographic_location)
 );
 
 create table if not exists data_science_workspace.building_populations(
   id SERIAL PRIMARY KEY,
-  reference_date INTEGER default 2021,
-  municipal_name TEXT not null,
+  reference_date INTEGER,
+  municipal_name INTEGER references data_science_workspace.municipal_district,
   dwellings_occupied_by_usual_residents INTEGER,
-  population_in_dwellings INTEGER
+  population_in_dwellings INTEGER,
+  UNIQUE(reference_date,municipal_name)
 );
 
 create table if not exists data_clean_room.buildings(
   id SERIAL PRIMARY KEY,
-  longitude decimal,
-  latitude decimal,
-  csduid text,
-  csdname text,
-  data_prov text,
-  build_id text,
-  shape_length decimal,
-  shape_footprint_area decimal
+  longitude decimal(16,12),
+  latitude decimal(16,12),
+  csduid varchar(10),
+  csdname varchar(100),
+  data_prov varchar(100),
+  build_id varchar(16),
+  shape_length decimal(18,12),
+  shape_footprint_area decimal(20,12),
+  UNIQUE (build_id)
 );
 
 create table if not exists data_science_workspace.municipal_building(
   id SERIAL primary key,
-  municipal_name text not null,
+  municipal_name INTEGER references data_science_workspace.municipal_district,
   total_buildings integer,
   total_building_area decimal,
   UNIQUE (municipal_name)

--- a/schema/deploy/tables/waste_data.sql
+++ b/schema/deploy/tables/waste_data.sql
@@ -1,0 +1,48 @@
+-- Deploy eed:tables/waste_data to pg
+
+BEGIN;
+
+create table if not exists data_science_workspace.regional_district(
+  id SERIAL PRIMARY KEY,
+  district_name TEXT not null,
+  district_shape GEOMETRY(multipolygon, 3005),
+  UNIQUE (district_name)
+);
+
+create table if not exists data_science_workspace.municipal_district(
+  id SERIAL PRIMARY KEY,
+  municipal_legal_name varchar(100),
+  municipal_abbreviated_name varchar(100),
+  municipal_shape GEOMETRY(multipolygon, 3005),
+  regional_district INTEGER references data_science_workspace.regional_district,
+  UNIQUE (municipal_legal_name)
+);
+
+create table if not exists data_clean_room.raw_regional_waste_data(
+  id SERIAL PRIMARY key,
+  regional_district_name text not null,
+  reporting_year INTEGER,
+  total_disposed_tonnes DECIMAL,
+  population_count INTEGER,
+  disposal_rate_kg DECIMAL,
+  UNIQUE (regional_district_name, reporting_year)
+);
+
+create table if not exists data_science_workspace.regional_waste_data(
+  id SERIAL PRIMARY Key,
+  regional_district INTEGER references data_science_workspace.regional_district,
+  year INTEGER,
+  total_disposed_tonnes DECIMAL,
+  population_count INTEGER,
+  UNIQUE (regional_district, year)
+);
+
+-- dev roles
+grant all on data_clean_room.raw_regional_waste_data, data_science_workspace.regional_district, data_science_workspace.municipal_district, data_science_workspace.regional_waste_data to eed_internal, eed_external, eed_admin;
+-- -- analyst
+grant all on data_clean_room.raw_regional_waste_data, data_science_workspace.regional_district, data_science_workspace.municipal_district, data_science_workspace.regional_waste_data to analyst;
+-- manager
+grant all on data_science_workspace.regional_district, data_science_workspace.municipal_district, data_science_workspace.regional_waste_data to manager;
+
+
+COMMIT;

--- a/schema/revert/tables/building_data.sql
+++ b/schema/revert/tables/building_data.sql
@@ -1,0 +1,10 @@
+-- Revert eed:tables/building_data from pg
+
+BEGIN;
+
+DROP TABLE data_science_workspace.municipal_building;
+DROP TABLE data_science_workspace.building_populations;
+DROP TABLE data_clean_room.buildings;
+DROP TABLE data_clean_room.dwelling_populations;
+
+COMMIT;

--- a/schema/revert/tables/waste_data.sql
+++ b/schema/revert/tables/waste_data.sql
@@ -1,0 +1,10 @@
+-- Revert eed:tables/waste_data from pg
+
+BEGIN;
+
+drop table if exists data_science_workspace.regional_waste_data;
+drop table if exists data_science_workspace.municipal_district;
+drop table if exists data_science_workspace.regional_district;
+drop table if exists data_clean_room.raw_regional_waste_data;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -22,3 +22,4 @@ tables/import_record [tables/import_record@alpha-23-01-18 add_data_schemas] 2023
 tables/study_area_geometry 2023-01-19T17:00:50Z Josh Gamache <joshua@button.is> # Add table for study area hexes
 tables/add_id_to_insights_voyage [tables/insight-destination-processed@alpha-23-01-18] 2023-01-20T17:20:26Z Josh Gamache <joshua@button.is> # Adds an additional id column to insights voyage table
 computed_columns/voyage_combined_id 2023-01-20T17:57:07Z Josh Gamache <joshua@button.is> # Add computed column for insights_voyage table combining origing_id and destination_id
+tables/waste_data 2023-01-20T22:19:23Z Josh Gamache <joshua@button.is> # Tables for waste reporting data

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -23,3 +23,4 @@ tables/study_area_geometry 2023-01-19T17:00:50Z Josh Gamache <joshua@button.is> 
 tables/add_id_to_insights_voyage [tables/insight-destination-processed@alpha-23-01-18] 2023-01-20T17:20:26Z Josh Gamache <joshua@button.is> # Adds an additional id column to insights voyage table
 computed_columns/voyage_combined_id 2023-01-20T17:57:07Z Josh Gamache <joshua@button.is> # Add computed column for insights_voyage table combining origing_id and destination_id
 tables/waste_data 2023-01-20T22:19:23Z Josh Gamache <joshua@button.is> # Tables for waste reporting data
+tables/building_data 2023-01-23T22:22:51Z Josh Gamache <joshua@button.is> # Add tables for handling building data

--- a/schema/verify/tables/building_data.sql
+++ b/schema/verify/tables/building_data.sql
@@ -1,0 +1,21 @@
+-- Verify eed:tables/building_data on pg
+
+BEGIN;
+
+select id, reference_date, geographic_location, dwellings_occupied_by_usual_residents, population_in_dwellings
+  from data_clean_room.dwelling_populations
+  where false;
+
+select id, reference_date, municipal_name, dwellings_occupied_by_usual_residents, population_in_dwellings
+  from data_science_workspace.building_populations
+  where false;
+
+select id, longitude, latitude, csduid, csdname, data_prov, build_id, shape_length, shape_footprint_area
+  from data_clean_room.buildings
+  where false;
+
+select id, municipal_name, total_buildings, total_building_area
+  from data_science_workspace.municipal_building
+  where false;
+
+ROLLBACK;

--- a/schema/verify/tables/waste_data.sql
+++ b/schema/verify/tables/waste_data.sql
@@ -1,0 +1,21 @@
+-- Verify eed:tables/waste_data on pg
+
+BEGIN;
+
+select id, district_name, district_shape
+  from data_science_workspace.regional_district
+  where false;
+
+select id, municipal_legal_name, municipal_abbreviated_name, municipal_shape, regional_district
+  from data_science_workspace.municipal_district
+  where false;
+
+select id, regional_district_name, reporting_year, total_disposed_tonnes, population_count, disposal_rate_kg
+  from data_clean_room.raw_regional_waste_data
+  where false;
+
+select id, regional_district, year, total_disposed_tonnes, population_count
+  from data_science_workspace.regional_waste_data
+  where false;
+
+ROLLBACK;


### PR DESCRIPTION
Addresses #181. Adds tables and dags required to handle Waste data and Building data. 

## Changes

- add schema for DCR (Data Clean Room) tables for Waste and Building data
- add schema for DSW (Data Science Workspace) tables for Waste and Building data
- add dag to ingest Waste and Building data into DCR
- add dag to process Waste and Building data into usable data in DSW

## To test

- Run `sqitch deploy` (on a database at develop), then `sqitch verify` (and check that it passes), `sqitch revert --to @HEAD^` (with any relevant configs like `-t eed_test` or `--cd schema` if in the root directory) 
