### PR TITLE
feat!: replace analytics page with metabase embeded iframe

### DIFF
--- a/app/app/[lng]/analyst/analytic/page.tsx
+++ b/app/app/[lng]/analyst/analytic/page.tsx
@@ -1,53 +1,7 @@
-import { Suspense } from "react";
 import { languages, fallbackLng } from "@/i18n/settings";
 import { useTranslation } from "@/i18n";
-import { gql } from "graphql-request";
 import BoxLabel from "@/components/layout/BoxLabel";
-import { Spinner } from "@/components/layout/Spinner";
-import DataQuery from "@/components/table/DataQuery";
-import { GridColDef } from "@mui/x-data-grid";
 
-// 👇️ graphQL query
-const query = gql`
-  {
-    insightsVoyages {
-      nodes {
-        id
-        originAreaId
-        destinationAreaId
-        voyageCount
-      }
-    }
-  }
-`;
-// 👇️ graphQL query endpoint
-const endpoint = "api/analyst/graphql";
-
-// 👇️ DataTable column definition of query data
-const columns: GridColDef[] = [
-  {
-    field: "id",
-    width: 50,
-  },
-  {
-    field: "originAreaId",
-    headerName: "0",
-    type: "number",
-    width: 200,
-  },
-  {
-    field: "destinationAreaId",
-    headerName: "1",
-    type: "number",
-    width: 200,
-  },
-  {
-    field: "voyageCount",
-    headerName: "2",
-    type: "number",
-    width: 200,
-  },
-];
 export default async function Page({
   params: { lng },
 }: {
@@ -58,26 +12,21 @@ export default async function Page({
   // 👇️ language management, server side
   if (languages.indexOf(lng) < 0) lng = fallbackLng;
   const { t } = await useTranslation(lng, "analytic");
-  // 👇️ translate column titles
-  columns.map((column, index) => {
-    if (column.headerName) {
-      column.headerName = t("column" + index.toString());
-    }
-  });
 
   // 👉️ return: table with query data
   return (
     <>
       <div>
         <BoxLabel text={t("label")}></BoxLabel>
-        <Suspense fallback={<Spinner />}>
-          {/* @ts-expect-error Async Server Component */}
-          <DataQuery
-            endpoint={endpoint}
-            query={query}
-            columns={columns}
-          ></DataQuery>
-        </Suspense>
+        <iframe
+          src="http://34.125.212.21:3000/public/dashboard/fdf8e976-1b80-44ad-ade5-5097444352db"
+          frameBorder="0"
+          style={{ overflow: "hidden", height: "100vh", width: "100%" }}
+          width="100%"
+          height="100%"
+          // eslint-disable-next-line react/no-unknown-property
+          allowTransparency
+        ></iframe>
       </div>
     </>
   );


### PR DESCRIPTION
Addresses #179. Replaces the direct query to the database (via graphQL) for the analytics with an iFrame generated by Metabase (hosted on our GCP). Displays information from all three tracks. 

## Changes

- Removed queries and supporting code
- Added iFrame sourced from Metabase

## To test

- spin up a local copy, log in as an analyst and navigate to `/en/analyst/analytic`. The Metabase iFrame should now be the main component.
