### PR TITLE
chore: load insights dataset with data clean room

### DIFF
--- a/schema/deploy/tables/raw_insights.sql
+++ b/schema/deploy/tables/raw_insights.sql
@@ -1,0 +1,30 @@
+-- Deploy eed:tables/raw_insights to pg
+
+BEGIN;
+
+create table if not exists data_clean_room.insights_job(
+  id TEXT PRIMARY KEY,
+  job_type TEXT,
+  study_zones TEXT[],
+  job_status TEXT,
+  request_id TEXT,
+  created_date TIMESTAMP,
+  updated_date TIMESTAMP not null DEFAULT NOW()
+);
+
+create table if not exists data_clean_room.raw_insights(
+  id SERIAL PRIMARY KEY,
+  job_id TEXT REFERENCES data_clean_room.insights_job(id),
+  input_geoid TEXT,
+  timeframe_bucket TIMESTAMP,
+  output_geoid TEXT,
+  count INTEGER,
+  UNIQUE (input_geoid, output_geoid)
+);
+
+-- dev roles
+grant all on data_clean_room.insights_job, data_clean_room.raw_insights to eed_internal, eed_external, eed_admin;
+-- -- analyst
+grant all on data_clean_room.insights_job, data_clean_room.raw_insights to analyst;
+
+COMMIT;

--- a/schema/revert/tables/insight-destination-processed@alpha-23-01-18.sql
+++ b/schema/revert/tables/insight-destination-processed@alpha-23-01-18.sql
@@ -2,8 +2,8 @@
 
 BEGIN;
 
-drop table eed.area_distance_map;
-drop table eed.insights_voyage;
-drop table eed.study_area;
+drop table if exists eed.area_distance_map;
+drop table if exists eed.insights_voyage;
+drop table if exists eed.study_area;
 
 COMMIT;

--- a/schema/revert/tables/raw_insights.sql
+++ b/schema/revert/tables/raw_insights.sql
@@ -1,0 +1,8 @@
+-- Revert eed:tables/raw_insights from pg
+
+BEGIN;
+
+drop table if exists data_clean_room.raw_insights;
+drop table if exists data_clean_room.insights_job;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -24,3 +24,4 @@ tables/add_id_to_insights_voyage [tables/insight-destination-processed@alpha-23-
 computed_columns/voyage_combined_id 2023-01-20T17:57:07Z Josh Gamache <joshua@button.is> # Add computed column for insights_voyage table combining origing_id and destination_id
 tables/waste_data 2023-01-20T22:19:23Z Josh Gamache <joshua@button.is> # Tables for waste reporting data
 tables/building_data 2023-01-23T22:22:51Z Josh Gamache <joshua@button.is> # Add tables for handling building data
+tables/raw_insights 2023-01-30T21:49:01Z Josh Gamache <joshua@button.is> # add raw insights tables for DCR

--- a/schema/verify/tables/raw_insights.sql
+++ b/schema/verify/tables/raw_insights.sql
@@ -1,0 +1,13 @@
+-- Verify eed:tables/raw_insights on pg
+
+BEGIN;
+
+select id, job_type, study_zones, job_status, request_id, created_date, updated_date
+  from data_clean_room.insights_job
+  where false;
+
+select id, job_id, input_geoid, timeframe_bucket, output_geoid, count
+  from data_clean_room.raw_insights
+  where false;
+
+ROLLBACK;


### PR DESCRIPTION
Addresses #190. Changes the Insights ingestion DAGs to load first into the Data Clean Room and then from there into the Data Science Workspace. 

## Changes

- Added tables to DCR in Sqitch plan to accommodate Insights data
- Updated insights ingestion DAG to load through DCR first
- Updated DAG to add a row to the import record table on each import (for Insights as well as Building and Waste data)
