### PR TITLE
fix: correct non-functioning GCP DAGs

### DIFF
--- a/dags/sample-waste-data-ingestion-dag.py
+++ b/dags/sample-waste-data-ingestion-dag.py
@@ -8,10 +8,7 @@ from airflow.utils.dates import days_ago
 from datetime import timedelta
 from google.cloud import storage
 from airflow.models import DAG
-import google.cloud.dlp
-
-# Instantiate DLP
-dlp = google.cloud.dlp_v2.DlpServiceClient()
+from google.cloud import dlp_v2
 
 default_args = {
   'email': ['joshua@button.is'],
@@ -128,6 +125,19 @@ def dlp_analyze_waste_table(task_instance):
     "VERY_LIKELY": 5
     }
 
+  reverse_likelihood_map = {
+  0: "LIKELIHOOD_UNSPECIFIED",
+  1: "VERY_UNLIKELY",
+  2: "UNLIKELY",
+  3: "POSSIBLE",
+  4: "LIKELY",
+  5: "VERY_LIKELY"
+  }
+
+
+  # Instantiate DLP
+  dlp = dlp_v2.DlpServiceClient()
+
   import_record_id = task_instance.xcom_pull(task_ids='waste_db_ingestion')
 
 
@@ -153,7 +163,7 @@ def dlp_analyze_waste_table(task_instance):
   table_json["rows"] = rows
 
   # Pass the json to DLP for analysis
-  item = {"table": table_json}
+  item: dlp_v2.ContentItem = {"table": table_json}
 
   # By not specifying an info_types array, we query against all info types
   inspect_config = {
@@ -165,13 +175,7 @@ def dlp_analyze_waste_table(task_instance):
   parent = f"projects/{project}"
 
   # Call the API
-  response = dlp.inspect_content(
-    request={
-      "parent": parent,
-      "inspect_config": inspect_config,
-      "item": item
-    }
-  )
+  response = dlp.inspect_content(parent=parent,inspect_config=inspect_config,item=item)
 
   # Process the results.
   if response.result.findings:
@@ -181,11 +185,12 @@ def dlp_analyze_waste_table(task_instance):
       content_location = next(iter(finding.location.content_locations), {})
       head = content_location.record_location.field_id.name
       infotype_found = finding.info_type.name
-      how_likely = str(finding.likelihood).replace("Likelihood.", "")
-      how_likely_number =  likelihood_map[how_likely]
+      how_likely_number = finding.likelihood
+      how_likely = reverse_likelihood_map.get(how_likely_number)
       quote = finding.quote
-      finding_id = finding.finding_id
+      finding_id = "" # ID not available in this API response
 
+      print(f"{head}, {infotype_found}, {how_likely}, {how_likely_number}")
       if head and head not in columns_with_findings:
         columns_with_findings[head] = {
           "infotype_found": infotype_found,


### PR DESCRIPTION
The DAGs that were approved with 196 _did not work_ on GCP. I'm not sure exactly why, but there were inconsistencies with the API being addressed by the DAG that caused failures in the DAG. This PR fixes those (while continuing to work in a local environment).

These DAGs have been deployed to GCP (only way to test). Status of these can be checked with the Airflow UI linked from [GCP's Composer page](https://console.cloud.google.com/composer/environments/detail/us-west3/eed-test/monitoring?project=emissions-elt-demo).