### PR TITLE
feat: add data fetching to dlp analysis report page

### DIFF
--- a/app/app/components/route/imported/id/Area.tsx
+++ b/app/app/components/route/imported/id/Area.tsx
@@ -14,7 +14,7 @@ export default async function Page({ lng, id, endpoint }) {
   // 👇️ graphQL query
   const query = gql`
   {
-    dlpTableColumns(filter: { tableAnalysisId: { equalTo: ${id} } }) {
+    dlpTableColumns(filter: { jobId: { equalTo: "${id}" } }) {
       nodes {
         columnAnalysis {
           columnTitle
@@ -23,14 +23,7 @@ export default async function Page({ lng, id, endpoint }) {
           toAnonymize
           quotes
         }
-        tableAnalysis {
-          importRecord {
-            fileName
-            trackFormat {
-              id
-            }
-          }
-        }
+        jobId
       }
     }
   }

--- a/app/app/components/route/imported/id/Area.tsx
+++ b/app/app/components/route/imported/id/Area.tsx
@@ -7,27 +7,34 @@ import Tag from "@/components/layout/Tag";
 import { columnsImportedArea } from "@/lib/table/columns";
 import { crumbsImportedArea } from "@/lib/navigation/crumbs";
 
+// 👇️ used to changes options for @/components/table/DataTable
+const cntx = "dlpAnalysis";
+
 export default async function Page({ lng, id, endpoint }) {
   // 👇️ graphQL query
-  const query =
-    gql`
-    {
-      importRecords(condition: { jobId: ` +
-    id +
-    `}) {
-        nodes {
-          fileName
-          submissionDate
-          trackFormat {
-            nickname
-          }
-          uploadedByUser {
-            email
+  const query = gql`
+  {
+    dlpTableColumns(filter: { tableAnalysisId: { equalTo: ${id} } }) {
+      nodes {
+        columnAnalysis {
+          columnTitle
+          identifiedInfoType
+          maxLikelihood
+          toAnonymize
+          quotes
+        }
+        tableAnalysis {
+          importRecord {
+            fileName
+            trackFormat {
+              id
+            }
           }
         }
       }
     }
-  `;
+  }
+`;
   // 👇️ language management
   const { t } = await useTranslation(lng, "tag");
   // 👇️ translate titles
@@ -47,6 +54,7 @@ export default async function Page({ lng, id, endpoint }) {
           endpoint={endpoint}
           query={query}
           columns={columnsImportedArea}
+          cntx={cntx}
         ></DataTableQuery>
       </Suspense>
     </>

--- a/app/app/components/table/DataTable.tsx
+++ b/app/app/components/table/DataTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 import MUIDataTable from "mui-datatables";
+import { Checkbox } from "@mui/material";
 
 export default function DataTable({ rows, columns, cntx }): JSX.Element {
   // 👇️ used to changes options for calling component
@@ -24,6 +25,31 @@ export default function DataTable({ rows, columns, cntx }): JSX.Element {
 
   switch (cntx) {
     case "anonymized":
+    case "dlpAnalysis":
+      // 👇️ get first quote from quote array for example
+      if (rows) {
+        rows = rows.map((row) => {
+          return {
+            ...row,
+            quotes: row[0] || "", // Quotes return as object keys rather than an array due to flattening
+          };
+        });
+      }
+
+      // 👇️ change 'to Anonymize?' column to a checkbox
+      // Todo: Enable functionality of checkbox (ie. submit back to DB & use for DLP anonymization)
+      const toAnonymizeIndex = columns.findIndex(
+        (e) => e.name === "toAnonymize"
+      );
+      columns[toAnonymizeIndex] = {
+        ...columns[toAnonymizeIndex],
+        options: {
+          customBodyRender: (value) => (
+            <Checkbox checked={value} disabled size="small" />
+          ),
+        },
+      };
+      break;
     case "imported":
       opts = { onRowClick: handleRowClick };
       break;

--- a/app/app/components/table/DataTable.tsx
+++ b/app/app/components/table/DataTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 import MUIDataTable from "mui-datatables";
 import { Checkbox } from "@mui/material";
+import { AlliumProvider, Link } from "@telus-uds/ds-allium";
 
 export default function DataTable({ rows, columns, cntx }): JSX.Element {
   // 👇️ used to changes options for calling component
@@ -51,6 +52,23 @@ export default function DataTable({ rows, columns, cntx }): JSX.Element {
       };
       break;
     case "imported":
+      // 👇️ change 'Sensitivity' column to link to dlp Analysis page
+      const sensitivityIndex = columns.findIndex(
+        (e) => e.name === "sensitivity"
+      );
+      columns[sensitivityIndex] = {
+        ...columns[sensitivityIndex],
+        options: {
+          customBodyRender: (_value, tableMeta) => {
+            const jobId = tableMeta.rowData[0];
+            return (
+              <AlliumProvider>
+                <Link href={`./imported/${jobId}`}>view report</Link>
+              </AlliumProvider>
+            );
+          },
+        },
+      };
       opts = { onRowClick: handleRowClick };
       break;
     case "connection":

--- a/app/app/i18n/locales/en/tag/page.json
+++ b/app/app/i18n/locales/en/tag/page.json
@@ -69,6 +69,15 @@
     }
   },
   "imported": {
+    "analysis": {
+      "columns": {
+        "0": "Column Title",
+        "1": "Identified Info Type",
+        "2": "Likelihood",
+        "3": "Example",
+        "4": "Anonymize?"
+      }
+    },
     "dataset": {
       "columns": {
         "0": "Dataset",

--- a/app/app/i18n/locales/en/tag/page.json
+++ b/app/app/i18n/locales/en/tag/page.json
@@ -92,7 +92,8 @@
         "0": "Dataset",
         "1": "Connector",
         "2": "Imported Date",
-        "3": "Imported By"
+        "3": "Imported By",
+        "4": "Sensitivity"
       },
       "tag": "Imported datasets"
     }

--- a/app/lib/table/columns.tsx
+++ b/app/lib/table/columns.tsx
@@ -36,8 +36,9 @@ export const columnsImported = [
   { label: "imported.datasets.columns.3", name: "email" },
 ];
 export const columnsImportedArea = [
-  { label: "imported.dataset.columns.0", name: "fileName" },
-  { label: "imported.dataset.columns.1", name: "nickname" },
-  { label: "imported.dataset.columns.2", name: "submissionDate" },
-  { label: "imported.dataset.columns.3", name: "email" },
+  { label: "imported.analysis.columns.0", name: "columnTitle" },
+  { label: "imported.analysis.columns.1", name: "identifiedInfoType" },
+  { label: "imported.analysis.columns.2", name: "maxLikelihood" },
+  { label: "imported.analysis.columns.3", name: "quotes" },
+  { label: "imported.analysis.columns.4", name: "toAnonymize" },
 ];

--- a/app/lib/table/columns.tsx
+++ b/app/lib/table/columns.tsx
@@ -34,6 +34,7 @@ export const columnsImported = [
   { label: "imported.datasets.columns.1", name: "nickname" },
   { label: "imported.datasets.columns.2", name: "submissionDate" },
   { label: "imported.datasets.columns.3", name: "email" },
+  { label: "imported.datasets.columns.4", name: "sensitivity" },
 ];
 export const columnsImportedArea = [
   { label: "imported.analysis.columns.0", name: "columnTitle" },

--- a/schema/deploy/computed_columns/dlp_column_table_jobid.sql
+++ b/schema/deploy/computed_columns/dlp_column_table_jobid.sql
@@ -1,0 +1,17 @@
+-- Deploy eed:computed_columns/voyage_combined_id to pg
+
+BEGIN;
+
+create or replace function data_clean_room.dlp_table_column_job_id(dtc_id data_clean_room.dlp_table_column)
+returns varchar as $computed_column$
+  select dta.import_record_id
+    from data_clean_room.dlp_table_analysis dta
+    where dtc_id.table_analysis_id = dta.id;
+$computed_column$ language sql stable;
+
+grant execute on function data_clean_room.dlp_table_column_job_id to eed_internal, eed_external, eed_admin;
+grant execute on function data_clean_room.dlp_table_column_job_id to analyst, manager;
+
+comment on function data_clean_room.dlp_table_column_job_id is 'Computed column for postgraphile to retrieve the job id related to a table analysis';
+
+COMMIT;

--- a/schema/deploy/tables/dlp_column_table_ref.sql
+++ b/schema/deploy/tables/dlp_column_table_ref.sql
@@ -1,0 +1,18 @@
+-- Deploy eed:tables/dlp_column_table_ref to pg
+
+BEGIN;
+
+create table if not exists data_clean_room.dlp_table_column (
+  table_analysis_id int not null references data_clean_room.dlp_table_analysis (id)
+    on update cascade on delete cascade,
+  column_analysis_id int not null references data_clean_room.dlp_column_analysis (id)
+    on update cascade,
+  PRIMARY KEY (table_analysis_id, column_analysis_id)
+);
+
+-- dev roles
+grant all on data_clean_room.dlp_table_column to eed_internal, eed_external, eed_admin;
+-- -- analyst
+grant all on data_clean_room.dlp_table_column to analyst;
+
+COMMIT;

--- a/schema/revert/computed_columns/dlp_column_table_jobid.sql
+++ b/schema/revert/computed_columns/dlp_column_table_jobid.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-drop function if exists data_science_workspace.insights_voyage_voyage_id;
+drop function if exists data_clean_room.dlp_table_column_job_id;
 
 COMMIT;

--- a/schema/revert/tables/dlp_column_table_ref.sql
+++ b/schema/revert/tables/dlp_column_table_ref.sql
@@ -1,0 +1,7 @@
+-- Revert eed:tables/dlp_column_table_ref from pg
+
+BEGIN;
+
+drop table if exists data_clean_room.dlp_table_column;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -27,3 +27,4 @@ tables/building_data 2023-01-23T22:22:51Z Josh Gamache <joshua@button.is> # Add 
 tables/raw_insights 2023-01-30T21:49:01Z Josh Gamache <joshua@button.is> # add raw insights tables for DCR
 tables/dlp_analytics 2023-02-02T20:50:01Z Josh Gamache <joshua@button.is> # add tables to support dlp record keeping
 tables/dlp_column_table_ref 2023-02-07T14:34:34Z Josh Gamache <joshua@button.is> # add many-many ref table for easier postgraphile queries
+computed_columns/dlp_column_table_jobid 2023-02-09T17:33:48Z Josh Gamache <joshua@button.is> # add a computed column to the m-m dlp table to surface the imported jobId

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -26,3 +26,4 @@ tables/waste_data 2023-01-20T22:19:23Z Josh Gamache <joshua@button.is> # Tables 
 tables/building_data 2023-01-23T22:22:51Z Josh Gamache <joshua@button.is> # Add tables for handling building data
 tables/raw_insights 2023-01-30T21:49:01Z Josh Gamache <joshua@button.is> # add raw insights tables for DCR
 tables/dlp_analytics 2023-02-02T20:50:01Z Josh Gamache <joshua@button.is> # add tables to support dlp record keeping
+tables/dlp_column_table_ref 2023-02-07T14:34:34Z Josh Gamache <joshua@button.is> # add many-many ref table for easier postgraphile queries

--- a/schema/verify/computed_columns/dlp_column_table_jobid.sql
+++ b/schema/verify/computed_columns/dlp_column_table_jobid.sql
@@ -1,0 +1,7 @@
+-- Verify eed:computed_columns/voyage_combined_id on pg
+
+BEGIN;
+
+select pg_get_functiondef('data_clean_room.dlp_table_column_job_id(data_clean_room.dlp_table_column)'::regprocedure);
+
+ROLLBACK;

--- a/schema/verify/tables/dlp_column_table_ref.sql
+++ b/schema/verify/tables/dlp_column_table_ref.sql
@@ -1,0 +1,9 @@
+-- Verify eed:tables/dlp_column_table_ref on pg
+
+BEGIN;
+
+select table_analysis_id, column_analysis_id
+  from data_clean_room.dlp_table_column
+  where false;
+
+ROLLBACK;


### PR DESCRIPTION
Adds data fetching for the Data Loss Prevention (DLP / anonymization) report page.

## Changes

- add many-to-many reference table linking _table analysis_ with respective _column analysis_, and surfacing a computed column for the relevant column in that table for assisting queries from Postgraphile.
- add fetching and formatted table in the column analysis page (anonymization checkbox is disabled but linked to DB data).
- link from imported datasets to column analysis.

## To test

Navigate to the Imported datasets page (`/en/analyst/imported`) and click on _view report_ in the sensitivity column. You should be directed to a page with that import's column analysis. The checkbox in the _Anonymize?_ column should be unchecked and disabled.

