### PR TITLE
feat: add Metabase and DLP to Terraform setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ After making changes to terraform code:
 - `terraform plan` to view what will be changed.
 - `terraform apply` to apply the changes to the cluster.
 - `terraform destroy` to tear down the resources.
+
+## Metabase
+
+A Metabase instance is spun up in a GCP Compute Engine VM for Pilot usage. Each instantiation of EED's metabase will have a new IP, so you will need to go into the GCP Console to acquire that IP. When logged in, you can go to the [Compute Engine VM dashboard](https://console.cloud.google.com/compute/instances?project=emissions-elt-demo) and look for an instance named "eed-metabase". You can copy the external IP and access on port `:3000`.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,6 +63,12 @@ module "cloud_composer" {
   depends_on     = [module.postgres, module.custom_iam]
 }
 
+module "metabase_vm" {
+  source  = "./modules/metabase_vm"
+  project = var.project
+  region  = var.region
+}
+
 module "triggers" {
   source               = "./modules/triggers"
   composer_dags_bucket = module.cloud_composer.composer_dags_bucket

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,6 +31,11 @@ module "custom_iam" {
   project = var.project
 }
 
+resource "google_project_service" "gcp_dlp_api" {
+  project = var.project
+  service = "dlp.googleapis.com"
+}
+
 module "postgres" {
   source  = "./modules/postgres"
   project = var.project

--- a/terraform/modules/cloud_composer/main.tf
+++ b/terraform/modules/cloud_composer/main.tf
@@ -36,6 +36,14 @@ resource "google_service_account_iam_member" "cloud_compose_sa" {
   member             = format("serviceAccount:service-%s@cloudcomposer-accounts.iam.gserviceaccount.com", var.project_number)
 }
 
+resource "google_service_account_iam_binding" "cloud_compose_sa" {
+  provider = google-beta
+  service_account_id = google_service_account.cloud_compose_sa.name
+  members   = [format("serviceAccount:service-%s@cloudcomposer-accounts.iam.gserviceaccount.com", var.project_number)]
+  // Role for Public IP environments
+  role = "roles/dlp.user"
+}
+
 # Create an environment that uses the custom service account.
 # You can add more parameters that define other configuration parameters of your environment
 #

--- a/terraform/modules/metabase_vm/main.tf
+++ b/terraform/modules/metabase_vm/main.tf
@@ -1,0 +1,64 @@
+module "gce-metabase-container" {
+  source  = "terraform-google-modules/container-vm/google"
+  version = "~> 2.0"
+
+  container = {
+    image = var.metabase_docker_image
+  }
+
+  restart_policy = "Always"
+}
+
+resource "google_compute_instance" "metabase_vm" {
+  project      = var.project
+  name         = var.metabase_name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  # If true, allows Terraform to stop the instance to update its properties.
+  allow_stopping_for_update = true
+
+  tags = [ "metabase" ]
+
+  boot_disk {
+    initialize_params {
+      # image = module.gce-metabase-container.source_image
+      image = module.gce-metabase-container.source_image
+    }
+  }
+
+  network_interface {
+    network = var.network_name
+
+    access_config {}
+  }
+
+  metadata = {
+    gce-container-declaration = module.gce-metabase-container.metadata_value
+  }
+
+
+  labels = {
+    container-vm = module.gce-metabase-container.vm_container_label
+  }
+}
+
+resource "google_compute_network" "default" {
+  name = var.network_name
+}
+
+resource "google_compute_firewall" "metabase" {
+  name        = var.metabase_name
+  network     = var.network_name
+  description = "Connection port for eed-metabase"
+  direction   = "INGRESS"
+
+  target_tags = [ "metabase" ]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3000"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}

--- a/terraform/modules/metabase_vm/outputs.tf
+++ b/terraform/modules/metabase_vm/outputs.tf
@@ -1,0 +1,9 @@
+output "metabase_external_address" {
+  value       = google_compute_instance.metabase_vm.network_interface.0.access_config.0.nat_ip
+  description = "Google Cloud VM external ip that hosts Metabase."
+}
+
+output "metabase_internal_address" {
+  value       = google_compute_instance.metabase_vm.network_interface.0.network_ip
+  description = "Google Cloud VM internal ip that hosts Metabase."
+}

--- a/terraform/modules/metabase_vm/variables.tf
+++ b/terraform/modules/metabase_vm/variables.tf
@@ -1,0 +1,34 @@
+variable "project" {
+  default     = "emissions-elt-demo"
+  description = "project id from GCP"
+}
+
+variable "metabase_name" {
+  default     = "eed-metabase"
+  description = "name of the Metabase VM"
+}
+
+variable "machine_type" {
+  default     = "e2-small"
+  description = "type of the Metabase VM"
+}
+
+variable "region" {
+  default     = "us-west4"
+  description = "GCP region"
+}
+
+variable "zone" {
+  default     = "us-west4-a"
+  description = "GCP zone"
+}
+
+variable "metabase_docker_image" {
+  default     = "docker.io/metabase/metabase:latest"
+  description = "address of the metabase docker image"
+}
+
+variable "network_name" {
+  default     = "default"
+  description = "name for the vm network"
+}


### PR DESCRIPTION
Addresses #218 . Adds a Metabase container deploy and enabling of the DLP api to the Terraform scripts. 

## Changes

- Add initialization of DLP api to Terraform script
- Add a containerized Metabase VM to Terraform script
